### PR TITLE
add full default, mack-news, mack-life and magazine indexes

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,0 +1,81 @@
+version: 1
+indices:
+  default:
+    include:
+      - '/**'
+    exclude:
+      - 'drafts/**'
+      - 'images/**'
+      - '/**/footer'
+      - '/**/nav'
+    target: /query-index.json
+    properties:
+      lastModified:
+        select: none
+        value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
+      title:
+        select: head > meta[property="og:title"]
+        value: attribute(el, "content")
+      image:
+        select: head > meta[property="og:image"]
+        value: match(attribute(el, "content"), "https:\/\/[^/]+(/.*)")
+      description:
+        select: head > meta[name="description"]
+        value: attribute(el, "content")
+  mack-news:
+    include:
+      - '/mack-news/**'
+    exclude:
+      - '/mack-news/'
+    target: /mack-news.json
+    properties:
+      template:
+        select: head > meta[name="template"]
+        value: attribute(el, "content")
+      title:
+        select: head > meta[property="og:title"]
+        value: attribute(el, "content")
+      image:
+        select: head > meta[property="og:image"]
+        value: match(attribute(el, "content"), "https:\/\/[^/]+(/.*)")
+      lastModified:
+        select: none
+        value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
+  mack-life:
+    include:
+      - '/mack-life/**'
+    exclude:
+      - '/mack-life/'
+    target: /mack-life.json
+    properties:
+      template:
+        select: head > meta[name="template"]
+        value: attribute(el, "content")
+      title:
+        select: head > meta[property="og:title"]
+        value: attribute(el, "content")
+      image:
+        select: head > meta[property="og:image"]
+        value: match(attribute(el, "content"), "https:\/\/[^/]+(/.*)")
+      lastModified:
+        select: none
+        value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
+  magazine:
+    include:
+      - '/magazine/**'
+    exclude:
+      - '/magazine/'
+    target: /magazine.json
+    properties:
+      template:
+        select: head > meta[name="template"]
+        value: attribute(el, "content")
+      title:
+        select: head > meta[property="og:title"]
+        value: attribute(el, "content")
+      image:
+        select: head > meta[property="og:image"]
+        value: match(attribute(el, "content"), "https:\/\/[^/]+(/.*)")
+      lastModified:
+        select: none
+        value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -29,6 +29,9 @@ indices:
       - '/mack-news/'
     target: /mack-news.json
     properties:
+      heading:
+        select: main div h1
+        value: textContent(el)
       template:
         select: head > meta[name="template"]
         value: attribute(el, "content")

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -32,11 +32,17 @@ indices:
       heading:
         select: main div h1
         value: textContent(el)
+      summary:
+        select: head > meta[property="summary"]
+        value: attribute(el, "content")
       template:
         select: head > meta[name="template"]
         value: attribute(el, "content")
       title:
         select: head > meta[property="og:title"]
+        value: attribute(el, "content")
+      date:
+        select: head > meta[property="date"]
         value: attribute(el, "content")
       image:
         select: head > meta[property="og:image"]


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #7 

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://7-set-up-whole-site-query-index--vg-macktrucks-com--hlxsites.hlx.page/
