### PR TITLE
Fix #64 Update to leverage mack-news feed.json index

### DIFF
--- a/blocks/news-sidebar/news-sidebar.js
+++ b/blocks/news-sidebar/news-sidebar.js
@@ -21,7 +21,7 @@ export default async function decorate(block) {
   // creating the year link
   const yearLink = document.createElement('a');
   const currentLink = newsPage && newsPage.find((item) => item.path === window.location.pathname);
-  const newsYear = (new Date(currentLink?.date)).getFullYear();
+  const newsYear = new Date(currentLink.publicationDate * 1000).getFullYear();
 
   if (!Number.isNaN(Number(newsYear))) {
     yearLink.setAttribute('href', `/mack-news/${newsYear}`);
@@ -39,7 +39,7 @@ export default async function decorate(block) {
       }
 
       newsItem.href = newsData.path;
-      newsItem.textContent = (newsData.heading && newsData.heading !== '0') ? newsData.heading : '';
+      newsItem.textContent = (newsData.title && newsData.title !== '0') ? newsData.title.split('|')[0] : '';
       li.append(newsItem);
       list.append(li);
     });
@@ -65,14 +65,15 @@ export default async function decorate(block) {
   const select = div.querySelector('select');
   newsPage.forEach((item) => {
     const option = createElement('option', [], { value: item.path });
-    option.textContent = item.heading;
+    const optionText = item.title.split('|')[0];
+    option.textContent = optionText;
     select.append(option);
   });
   const selectEl = div.firstElementChild;
   block.append(selectEl);
   select.addEventListener('change', (event) => {
     const selectedNews = newsPage.find((item) => item.path === event.target.value);
-    block.querySelector('.news-sidebar-select-text').textContent = selectedNews?.heading;
+    block.querySelector('.news-sidebar-select-text').textContent = selectedNews?.title.split('|')[0];
     window.location = event.target.value;
   });
 }

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -35,6 +35,9 @@ indices:
       - '/mack-news/fragments/**'
     target: /mack-news/feed.json
     properties:
+      template:
+        select: head > meta[name="template"]
+        value: attribute(el, "content")
       title:
         select: head > meta[property="og:title"]
         value: attribute(el, "content")

--- a/scripts/news.js
+++ b/scripts/news.js
@@ -6,7 +6,7 @@ import { getMetadata } from './lib-franklin.js';
 async function loadMoreNews() {
   if (!window.mack.newsData.allLoaded) {
     const queryLimit = 200;
-    const resp = await fetch(`/mack-news.json?limit=${queryLimit}&offset=${window.mack.newsData.offset}`);
+    const resp = await fetch(`/mack-news/feed.json?limit=${queryLimit}&offset=${window.mack.newsData.offset}`);
     const json = await resp.json();
     const { total, data } = json;
     window.mack.newsData.news.push(...data);


### PR DESCRIPTION
Includes new template property in the index definition Update of url to fetch news from feed.json
Update of corresponding properties to get the right data based on feed.json properties

Fix #64 

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/mack-news/2023/mack-dealer-bruckner-truck-sales-in-commerce-city-colorado-is-now-a-mack-ev-certified-dealer
- After: https://64-news-sidebar-invalid-year--vg-macktrucks-com--hlxsites.hlx.page/mack-news/2023/mack-dealer-bruckner-truck-sales-in-commerce-city-colorado-is-now-a-mack-ev-certified-dealer
