### PR TITLE
Fix to get the title from meta tag instead of h1 tag

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -86,8 +86,8 @@ indices:
         select: head > meta[name="template"]
         value: attribute(el, "content")
       title:
-        select: h1
-        value: textContent(el)
+        select: head > meta[property="og:title"]
+        value: attribute(el, "content")
       subtitle:
         select: body > main > div > div.default-content-wrapper > h5
         value: textContent(el)


### PR DESCRIPTION
Fix #111 
Not picking up the title 'h1' not there switch to meta tag.

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://111-feat-add-magazine-index--vg-macktrucks-com--hlxsites.hlx.page/
