### PR TITLE
Updated CSS selector to get subtitle from page

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -89,7 +89,7 @@ indices:
         select: head > meta[property="og:title"]
         value: attribute(el, "content")
       subtitle:
-        select: body > main > div > div.default-content-wrapper > h5
+        select: h5
         value: textContent(el)
       description:
         select: head > meta[property="og:description"]


### PR DESCRIPTION
Fix #154 

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://154-fix-subtitle-magazine-articles--vg-macktrucks-com--hlxsites.hlx.page/
