### PR TITLE
#98 & #99 center img & img on top

### DIFF
--- a/blocks/sub-nav/sub-nav.css
+++ b/blocks/sub-nav/sub-nav.css
@@ -56,6 +56,10 @@
   visibility: inherit;
 }
 
+.sub-nav-container .sub-nav-title {
+  flex: 1 0 20%;
+}
+
 .sub-nav-container > .fa-caret-up ~ .sub-nav-title {
   box-shadow: 0 2px var(--secondary-steel);
   width: 100%;

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -37,6 +37,16 @@
   flex: 1 1 100%;
 }
 
+.tabs-tab-item.active .tab-picture-wrapper {
+  display: flex;
+  justify-content: center;
+  order: 1;
+}
+
+.tabs-tab-item.active .tab-text-wrapper {
+  order: 2;
+}
+
 .tabs-tab-item.active picture {
   display: inline-block;
 }
@@ -55,6 +65,10 @@
 @media (min-width: 748px) {
   .tabs-tab-item.active {
     flex-direction: initial;
+  }
+
+  .tabs-tab-item.active :is(.tab-text-wrapper , .tab-picture-wrapper) {
+    order: unset;
   }
 }
 

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -11,6 +11,13 @@ export default function decorate(block) {
   defaultActive.className = 'active';
   // make tab-titles focusable
   [...tabTitles.children].forEach((li) => { li.tabIndex = 0; });
+  // add picture & text wrappers a css class
+  [...items].forEach((item) => {
+    const picture = item.querySelector('picture');
+    const p = item.querySelector('p');
+    picture.parentElement.className = 'tab-picture-wrapper';
+    p.parentElement.className = 'tab-text-wrapper';
+  });
 
   const setActiveTab = (e) => {
     if (e.target.localName !== 'li') return;


### PR DESCRIPTION
Images now are aligned centre in its column and are always on top on mobile viewport independently if in desktop are left or right aligned

Fix #98 #99

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/parts-and-services/parts/mack-parts/engine
- After: https://98-tabs-image-alignments--vg-macktrucks-com--hlxsites.hlx.page/parts-and-services/parts/mack-parts/engine
