### PR TITLE
enable search indice on helix-query

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -109,3 +109,35 @@ indices:
       lastModified:
         select: none
         value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
+  search:
+    include:
+      - '/**'
+    exclude:
+      - '/drafts/**'
+      - 'images/**'
+      - '/**/footer'
+      - '/footer'
+      - '/**/nav'
+      - '/nav'
+      - '/fragments/**'
+      - '/**/sub-nav'
+      - '/block-library/**'
+    target: /query-index.json
+    properties:
+      lastModified:
+        select: none
+        value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
+      title:
+        select: head > meta[property="og:title"]
+        value: attribute(el, "content")
+      image:
+        select: head > meta[property="og:image"]
+        value: match(attribute(el, "content"), "https:\/\/[^/]+(/.*)")
+      description:
+        select: head > meta[name="description"]
+        value: attribute(el, "content")
+      text:
+        select: head > meta[name="content"]
+        value: attribute(el, "content")
+
+

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -112,6 +112,9 @@ indices:
   search:
     include:
       - '/**'
+      - '/mack-news/*/**'
+      - '/parts-and-services/support/body-builders/news-and-events/**'
+      - '/magazine/articles/*/**'
     exclude:
       - '/drafts/**'
       - 'images/**'
@@ -122,6 +125,9 @@ indices:
       - '/fragments/**'
       - '/**/sub-nav'
       - '/block-library/**'
+      - '/mack-news/fragments/**'
+      - '/parts-and-services/support/body-builders/news-and-events/'
+      - '/magazine/articles/'
     target: /query-index.json
     properties:
       lastModified:
@@ -130,12 +136,15 @@ indices:
       title:
         select: head > meta[property="og:title"]
         value: attribute(el, "content")
-      image:
-        select: head > meta[property="og:image"]
-        value: match(attribute(el, "content"), "https:\/\/[^/]+(/.*)")
       description:
         select: head > meta[name="description"]
         value: attribute(el, "content")
+      template:
+        select: head > meta[name="template"]
+        value: attribute(el, "content")
+      tags:
+        select: head > meta[property="article:tag"]
+        values: attribute(el, "content")
       text:
         select: head > meta[name="content"]
         value: attribute(el, "content")

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -139,8 +139,8 @@ indices:
       description:
         select: head > meta[name="description"]
         value: attribute(el, "content")
-      template:
-        select: head > meta[name="template"]
+      category:
+        select: head > meta[name="category"]
         value: attribute(el, "content")
       tags:
         select: head > meta[property="article:tag"]

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -146,7 +146,7 @@ indices:
         select: head > meta[property="article:tag"]
         values: attribute(el, "content")
       text:
-        select: head > meta[name="content"]
-        value: attribute(el, "content")
+        select: main
+        value: textContent(el)
 
 


### PR DESCRIPTION
Add new `search` indice on helix-query for the search connector

Fix #161 

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://161-new-search-index-helix-query--vg-macktrucks-com--hlxsites.hlx.page/
