### PR TITLE
URL corrected

### DIFF
--- a/blocks/teaser-grid/teaser-grid.js
+++ b/blocks/teaser-grid/teaser-grid.js
@@ -17,7 +17,7 @@ export default function decorate(block) {
     const subtitle = `${texts[2].innerText} >`;
 
     let categoriesUrl = buttonText.replaceAll(' ', '-').toLowerCase();
-    categoriesUrl = `${window.location.href}/categories/${categoriesUrl}`;
+    categoriesUrl = `${window.location.href}categories/${categoriesUrl}`;
 
     teaserGridItem.innerHTML = `
         <div class='teaser-card'>


### PR DESCRIPTION
Deleted extra "/" to make the categories urls work correctly

Fix #200

Test URLs:

- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/drafts/shomps/teasergrid
- After: https://200-bug-teaser-card--vg-macktrucks-com--hlxsites.hlx.page/drafts/shomps/teasergrid
