### PR TITLE
fix: migrate to new sidekick library

### DIFF
--- a/blocks/news-sidebar/news-sidebar.js
+++ b/blocks/news-sidebar/news-sidebar.js
@@ -76,7 +76,7 @@ function getParentCategoryLink(pagePath) {
   let parentFolderName = parentFolders.at(-1);
 
   // format the parent folder name to be more readable
-  parentFolderName = parentFolderName.replaceAll('-', ' ');
+  parentFolderName = parentFolderName?.replaceAll('-', ' ');
 
   const category = createElement('a', [], { href: `/${parentFolders.join('/')}/` });
   category.textContent = parentFolderName;

--- a/blocks/recent-articles/recent-articles.js
+++ b/blocks/recent-articles/recent-articles.js
@@ -1,5 +1,5 @@
 import { createElement, getTextLabel } from '../../scripts/scripts.js';
-import { createOptimizedPicture } from '../../scripts/lib-franklin.js';
+import { createOptimizedPicture, getOrigin } from '../../scripts/lib-franklin.js';
 
 const sectionTitle = getTextLabel('Recent article text');
 const readNowText = getTextLabel('READ NOW');
@@ -42,7 +42,7 @@ export default async function decorate(block) {
   const recentArticleList = createElement('ul', 'recent-articles-list');
 
   selectedArticles.forEach((e, idx) => {
-    const linkUrl = new URL(e.path, window.location.origin);
+    const linkUrl = new URL(e.path, getOrigin());
     const firstOrRest = (idx === 0) ? 'first' : 'rest';
 
     const item = createElement('li', `recent-articles-${firstOrRest}-item`);
@@ -55,7 +55,7 @@ export default async function decorate(block) {
     </a>`;
 
     const categoriesWithDash = e.category.replaceAll(' ', '-').toLowerCase();
-    const categoryUrl = new URL(`magazine/categories/${categoriesWithDash}`, window.location.origin);
+    const categoryUrl = new URL(`magazine/categories/${categoriesWithDash}`, getOrigin());
     const category = createElement('a', `recent-articles-${firstOrRest}-category`, { href: categoryUrl });
     category.innerText = e.category;
 

--- a/blocks/recommendations/recommendations.js
+++ b/blocks/recommendations/recommendations.js
@@ -3,6 +3,7 @@ import { getAllArticles, getLimit, clearRepeatedArticles } from '../recent-artic
 import {
   getMetadata,
   createOptimizedPicture,
+  getOrigin,
 } from '../../scripts/lib-franklin.js';
 
 const recommendationsText = getTextLabel('Recommendations text');
@@ -25,7 +26,7 @@ export default async function decorate(block) {
 
   selectedArticles.forEach((e, idx) => {
     const item = createElement('li', ['recommendations-item', `recommendations-item-${idx}`]);
-    const linkUrl = new URL(e.path, window.location.origin);
+    const linkUrl = new URL(e.path, getOrigin());
 
     const image = createElement('div', 'recommendations-image');
     const picture = createOptimizedPicture(e.image, e.title);
@@ -35,7 +36,7 @@ export default async function decorate(block) {
     </a>`;
 
     const categoriesWithDash = e.category.replaceAll(' ', '-').toLowerCase();
-    const categoryUrl = new URL(`magazine/categories/${categoriesWithDash}`, window.location.origin);
+    const categoryUrl = new URL(`magazine/categories/${categoriesWithDash}`, getOrigin());
 
     const content = createElement('div', 'recommendations-text-content');
     const categoryLink = createElement('a', 'recommendations-category', { href: categoryUrl });

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -6,8 +6,11 @@ sampleRUM('cwv');
 
 // add more delayed functionality here
 
-loadScript('https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', {
-  type: 'text/javascript',
-  charset: 'UTF-8',
-  'data-domain-script': 'bf50d0a6-e209-4fd4-ad2c-17da5f9e66a5',
-});
+// Prevent the cookie banner from loading when running in library
+if (!window.location.pathname.includes('srcdoc')) {
+  loadScript('https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', {
+    type: 'text/javascript',
+    charset: 'UTF-8',
+    'data-domain-script': 'bf50d0a6-e209-4fd4-ad2c-17da5f9e66a5',
+  });
+}

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -420,6 +420,28 @@ export async function loadBlocks(main) {
 }
 
 /**
+ * Returns the true origin of the current page in the browser.
+ * If the page is running in a iframe with srcdoc, the ancestor origin is returned.
+ * @returns {String} The true origin
+ */
+export function getOrigin() {
+  return window.location.href === 'about:srcdoc' ? window.parent.location.origin : window.location.origin;
+}
+
+/**
+ * Returns the true of the current page in the browser.mac
+ * If the page is running in a iframe with srcdoc,
+ * the ancestor origin + the path query param is returned.
+ * @returns {String} The href of the current page or the href of the block running in the library
+ */
+export function getHref() {
+  if (window.location.href !== 'about:srcdoc') return window.location.href;
+
+  const urlParams = new URLSearchParams(window.parent.location.search);
+  return `${window.parent.location.origin}${urlParams.get('path')}`;
+}
+
+/**
  * Returns a picture element with webp and fallbacks
  * @param {string} src The image URL
  * @param {string} [alt] The image alternative text
@@ -428,7 +450,7 @@ export async function loadBlocks(main) {
  * @returns {Element} The picture element
  */
 export function createOptimizedPicture(src, alt = '', eager = false, breakpoints = [{ media: '(min-width: 600px)', width: '2000' }, { width: '750' }]) {
-  const url = new URL(src, window.location.href);
+  const url = new URL(src, getHref());
   const picture = document.createElement('picture');
   const { pathname } = url;
   const ext = pathname.substring(pathname.lastIndexOf('.') + 1);

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -5,9 +5,7 @@
       "id": "library",
       "title": "Library",
       "environments": [ "edit" ],
-      "isPalette": true,
-      "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
-      "url": "https://hlx.live/tools/sidekick/library?base=https://main--vg-macktrucks-com--hlxsites.hlx.live/block-library/library.json",
+      "url": "https://main--vg-macktrucks-com--hlxsites.hlx.live/tools/sidekick/library.html",
       "includePaths": [ "**.docx**" ]
     },
     {

--- a/tools/sidekick/library.html
+++ b/tools/sidekick/library.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta name="Description" content="Sidekick Library" />
+    <meta name="robots" content="noindex" />
+    <base href="/" />
+
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: sans-serif;
+        background-color: #ededed;
+        height: 100%;
+      }
+    </style>
+    <title>Sidekick Library</title>
+  </head>
+
+  <body>
+    <script
+      type="module"
+      src="https://www.hlx.live/tools/sidekick/library/index.js"
+    ></script>
+    <script>
+      const library = document.createElement('sidekick-library')
+      library.config = {
+        base: '/block-library/library.json',
+      }
+
+      document.body.prepend(library)
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Do not merge until https://github.com/adobe/helix-website/pull/275 is merged
This PR migrates the macktrucks-com site to the new full screen version of the sidekick library.

Test URLs:

Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
After: https://sidekick-library-migration--vg-macktrucks-com--hlxsites.hlx.page/