### PR TITLE
#139 remove extra space & align tool icons

### DIFF
--- a/blocks/dealer-locator/dealer-locator.css
+++ b/blocks/dealer-locator/dealer-locator.css
@@ -98,7 +98,6 @@ main .section.dealer-locator-container > div {
 @media (max-width: 992px) {
     .dealer-locator {
         height:calc(100% - 6.1em)!important;
-        margin-top: 32px
     }
 }
 
@@ -819,7 +818,7 @@ main .section.dealer-locator-container > div {
         position: absolute;
         right: 90px;
         display: block;
-        top: -8px
+        top: -3px
     }
 
     .dealer-locator .mobile-main-header .panel-header .search-container button {
@@ -858,7 +857,7 @@ main .section.dealer-locator-container > div {
         position: absolute;
         right: 30px;
         display: block;
-        top: -8px
+        top: -3px
     }
 
     .dealer-locator .mobile-main-header .panel-header .filter-container button {
@@ -908,8 +907,8 @@ main .section.dealer-locator-container > div {
     .dealer-locator .mobile-main-header .panel-header .geo-container {
         display: block;
         position: absolute;
-        right: 0;
-        top: -8px
+        right: -5px;
+        top: 0
     }
 
     .dealer-locator .mobile-main-header .panel-header .geo-container button {


### PR DESCRIPTION
add this to the url path:
/buy-mack/find-a-dealer/

and switch to mobile view

Fix #139 

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://139-dealer-locator-extra-space--vg-macktrucks-com--hlxsites.hlx.page/
