### PR TITLE
Added summary & publicationDate to body builder news index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -62,11 +62,11 @@ indices:
         select: head > meta[property="og:title"]
         value: attribute(el, "content")
       summary:
-        select: head > meta[name="summary"]
+        select: head > meta[property="og:description"]
         value: attribute(el, "content")
       publicationDate:
-        select: head > meta[name="date"]
-        value: parseTimestamp(attribute(el, "content"), MM/DD/YYYY)
+        select: none
+        value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
   magazine-articles:
     include:
       - '/magazine/articles/*/**'


### PR DESCRIPTION
Update index of Body Builders news pages to include description as summary and lastModified date as publicationDate.

Fix #269 

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://269-update-bb-news-index--vg-macktrucks-com--hlxsites.hlx.page/
