### PR TITLE
#294 use closest Fn instead of custom ones

### DIFF
--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -1,4 +1,4 @@
-import { createElement, getTargetParentElement, getTextLabel } from '../../scripts/scripts.js';
+import { createElement, getTextLabel } from '../../scripts/scripts.js';
 import {
   getFacetsTemplate,
   getNoResultsTemplate,
@@ -21,7 +21,7 @@ const PLACEHOLDERS = {
 };
 
 export default function decorate(block) {
-  const section = getTargetParentElement(block, { className: 'section' });
+  const section = block.closest('.section');
   // check if the closest default content wrapper is inside the same section element
   const siblingDefaultSection = section.querySelector('.default-content-wrapper');
   const popularSearchWrapper = siblingDefaultSection || section.nextElementSibling;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -470,24 +470,6 @@ export function createIframe(url, { parentEl, classes = [] }) {
   return iframe;
 }
 
-/**
- * search recursively through the parent elements chain until find the target
- * element based on its tag or a CSS class
- * @param {HTMLElement} el the initial element or one of its parents
- * @param {object} option an option object using the key as search parameter
- * @param {string} option.tag to search by element tag
- * @param {string} option.className to search by a CSS class in the element
- * @returns {HTMLElement | null} the target element or null if is not found
- */
-export function getTargetParentElement(el, option) {
-  const [key] = Object.keys(option);
-  const checks = {
-    tag: el.parentElement.localName === option[key],
-    className: el.parentElement.classList.contains(option[key]),
-  };
-  if (checks[key] === undefined) return null;
-  return checks[key] ? el.parentElement : getTargetParentElement(el.parentElement, option);
-}
 /* this function load script only when it wasn't loaded yet */
 const scriptMap = new Map();
 


### PR DESCRIPTION
I thought I already removed all of them but it seems I miss one of them
_getTargetParentElement_ has been removed
_getParentSection_ It was already removed in previous PRs

Test in search page

Fix #294 

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://294-use-closest-function--vg-macktrucks-com--hlxsites.hlx.page/
