### PR TITLE
change margin for padding

### DIFF
--- a/blocks/features/features.css
+++ b/blocks/features/features.css
@@ -7,7 +7,7 @@
 
 .features .row > .feature {
     width: 100%;
-    margin-bottom: 100px
+    padding-bottom: 100px
 }
 
 .features .row img {


### PR DESCRIPTION
Did this to avoid white space after features block in **mobile view**

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/trucks/anthem/features/
- After: https://hotspots-padding--vg-macktrucks-com--hlxsites.hlx.page/trucks/anthem/features/
