### PR TITLE
329 dropdown is over subnav & below main menu

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -143,7 +143,7 @@ header nav[aria-expanded="true"] .nav-sections {
   visibility: visible;
   align-self: start;
   background-color: var(--primary-black);
-  z-index: 1;
+  z-index: 2;
 }
 
 header :where(nav[aria-expanded="true"]) .nav-sections .nav-mobile {
@@ -453,6 +453,7 @@ header .studio-search-widget {
 
 .autosuggest-results.show {
   display: block;
+  z-index: 1;
 }
 
 .autosuggest-results .result-row {


### PR DESCRIPTION
test instructions:
switch to a tablet or mobile viewport
open header search
start typing "truc" to open the autosuggestion dropdown
optional: open hamburger menu

result:
autosuggestion dropdow now is over subnav but under man menu


Fix #329 

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/trucks/
- After: https://329-suggestions-is-behind-subnav--vg-macktrucks-com--hlxsites.hlx.page/trucks/
