### PR TITLE
213 icons without arial label

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -1,10 +1,10 @@
 import { readBlockConfig, decorateIcons, loadBlocks } from '../../scripts/lib-franklin.js';
-import { createElement } from '../../scripts/scripts.js';
+import { createElement, getTextLabel } from '../../scripts/scripts.js';
 
 const PLACEHOLDERS = {
-  visit: 'Please, visit our $0',
-  social: 'social media',
-  channel: 'channel',
+  visit: getTextLabel('visit aria label'),
+  social: getTextLabel('social aria label'),
+  channel: getTextLabel('channel aria label'),
 };
 
 /**

--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -1,6 +1,12 @@
 import { readBlockConfig, decorateIcons, loadBlocks } from '../../scripts/lib-franklin.js';
 import { createElement } from '../../scripts/scripts.js';
 
+const PLACEHOLDERS = {
+  visit: 'Please, visit our $0',
+  social: 'social media',
+  channel: 'channel',
+};
+
 /**
  * loads and decorates the footer
  * @param {Element} block The header block element
@@ -29,6 +35,11 @@ export default async function decorate(block) {
 
     if (iconClass) {
       const iconName = iconClass.split('icon-')[1];
+      const link = icon.closest('a');
+      const social = iconName.replace('fa-', '');
+
+      link.ariaLabel = `${PLACEHOLDERS.visit.replace('$0', social)} ${
+        social !== 'youtube' ? PLACEHOLDERS.social : PLACEHOLDERS.channel}`;
 
       icon.classList.remove('icon', iconClass);
       icon.classList.add('fa', iconName, 'footer-social-media');

--- a/placeholder.json
+++ b/placeholder.json
@@ -1,7 +1,7 @@
 {
-  "total": 16,
+  "total": 21,
   "offset": 0,
-  "limit": 16,
+  "limit": 21,
   "data": [
     {
       "Key": "Low resolution video message",
@@ -74,6 +74,18 @@
     {
       "Key": "Load more articles button",
       "Text": "Load More Articles"
+    },
+    {
+      "Key": "visit aria label",
+      "Text": "Please, visit our $0"
+    },
+    {
+      "Key": "social aria label",
+      "Text": "social media"
+    },
+    {
+      "Key": "channel aria label",
+      "Text": "channel"
     }
   ],
   ":type": "sheet"


### PR DESCRIPTION
footer link icons (_a_ tag element) now have an aria-label text

Fix #213 

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://213-icons-without-arial-label--vg-macktrucks-com--hlxsites.hlx.page/
