### PR TITLE
Updated news limit to allow initial rendering of mack-news

### DIFF
--- a/scripts/news.js
+++ b/scripts/news.js
@@ -97,7 +97,7 @@ export class PagingInfo {
  */
 async function fetchJsonFeed(jsonFeedPath, pagingInfo) {
   if (!pagingInfo.allLoaded) {
-    const queryLimit = 200;
+    const queryLimit = 600;
     const resp = await fetch(`${jsonFeedPath}?limit=${queryLimit}&offset=${pagingInfo.offset}`);
     const json = await resp.json();
     const { total, data } = json;


### PR DESCRIPTION
Fix #378 
Although limit and offset are implemented, the way we are building and rendering mack-news pages (filtered by year '/mack-news/2023/ ) does not play well with offset pagination and would need a bigger refactoring and perhaps changing a bit of UX in this section. So, atm, increasing the initial limit to be able to render all published news.

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://378-mack-news-limit--vg-macktrucks-com--hlxsites.hlx.page/

