### PR TITLE
#403 Fix video cookie settings

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -393,7 +393,9 @@ export function isVideoLink(link) {
 
 export function selectVideoLink(links, preferredType) {
   const linksList = [...links];
-  const shouldUseYouTubeLinks = document.cookie.split(';').some((cookie) => cookie.trim().startsWith('OptanonConsent=1')) && preferredType !== 'local';
+  const optanonConsentCookieValue = decodeURIComponent(document.cookie.split(';').find((cookie) => cookie.trim().startsWith('OptanonConsent=')));
+  const cookieConsentForExternalVideos = optanonConsentCookieValue.includes('C0005:1');
+  const shouldUseYouTubeLinks = cookieConsentForExternalVideos && preferredType !== 'local';
   const youTubeLink = linksList.find((link) => link.getAttribute('href').includes('youtube.com/embed/'));
   const localMediaLink = linksList.find((link) => link.getAttribute('href').split('?')[0].endsWith('.mp4'));
 


### PR DESCRIPTION
Fix #403 

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/mack-connect/connected-driving/predictive-cruise/
- After: https://403-video-cookies--vg-macktrucks-com--hlxsites.hlx.page/mack-connect/connected-driving/predictive-cruise/
