### PR TITLE
#406 Loading GTM tracking only when user agrees

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -3,7 +3,13 @@ import { sampleRUM, loadScript } from './lib-franklin.js';
 
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
-loadGoogleTagManager();
+
+const cookieSetting = decodeURIComponent(document.cookie.split(';').find((cookie) => cookie.trim().startsWith('OptanonConsent=')));
+const isGtmAllowed = cookieSetting.includes('C0002:1');
+
+if (isGtmAllowed) {
+  loadGoogleTagManager();
+}
 
 // add more delayed functionality here
 


### PR DESCRIPTION
Fix #406 

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://406-gtm-tracking--vg-macktrucks-com--hlxsites.hlx.page/
