### PR TITLE
#496 youtube video loads in modal

### DIFF
--- a/scripts/video-helper.js
+++ b/scripts/video-helper.js
@@ -42,7 +42,7 @@ export function createLowResolutionBanner() {
 export function showVideoModal(linkUrl) {
   // eslint-disable-next-line import/no-cycle
   import('../common/modal/modal-component.js').then((modal) => {
-    let beforeBanner = null;
+    let beforeBanner = {};
 
     if (isLowResolutionVideoUrl(linkUrl)) {
       beforeBanner = createLowResolutionBanner();


### PR DESCRIPTION
if the cookies are accepted, then YouTube loads in the popup modal

Test URL:
trucks/anthem/

Fix #496 

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://496-youtube-videos-not-play--vg-macktrucks-com--hlxsites.hlx.page/
