### PR TITLE
onTrust only open in production

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -21,7 +21,7 @@ if (isPerformanceAllowed) {
 
 // Prevent the cookie banner from loading when running in library
 if (!window.location.pathname.includes('srcdoc')
-  && !['localhost', 'hlx.page'].includes(window.location.host)) {
+  && !['localhost', 'hlx.page'].some((url) => window.location.host.includes(url))) {
   loadScript('https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', {
     type: 'text/javascript',
     charset: 'UTF-8',


### PR DESCRIPTION
## Fix

the delayed.js conditional now handles whether the URL is in production or not

#

Test URLs:
- After: https://fix-ontrust-modal-for-production--vg-macktrucks-com--hlxsites.hlx.page/
