### PR TITLE
Sync Main domain to update header and explore blocks

### DIFF
--- a/.github/ci/generate-news-feed.js
+++ b/.github/ci/generate-news-feed.js
@@ -8,9 +8,9 @@ const feeds = [
   {
     title: 'Mack News',
     targetFile: `../../mack-news/feed.xml`,
-    source: 'https://main--vg-macktrucks-com--hlxsites.hlx.live/mack-news/feed.json',
-    siteRoot: "https://www.macktrucks.com",
-    link:	"https://www.macktrucks.com/mack-news/",
+    source: 'https://main--vg-macktrucks-com-co--hlxsites.hlx.live/mack-news/feed.json',
+    siteRoot: "https://www.macktrucks.com.co",
+    link:	"https://www.macktrucks.com.co/mack-news/",
     language:	"en",
     description:	"Get the latest news from Mack® Trucks and see how we are taking our Born Ready " +
       "semi truck line to the next level with new innovations and technology."
@@ -18,9 +18,9 @@ const feeds = [
   {
     title: 'Mack Body Builder News',
     targetFile: `../../parts-and-services/support/body-builders/news-and-events/feed.xml`,
-    source: 'https://main--vg-macktrucks-com--hlxsites.hlx.live/body-builder-news.json',
-    siteRoot: "https://www.macktrucks.com",
-    link:	"https://www.macktrucks.com/parts-and-services/support/body-builders/news-and-events/",
+    source: 'https://main--vg-macktrucks-com-co--hlxsites.hlx.live/body-builder-news.json',
+    siteRoot: "https://www.macktrucks.com.co",
+    link:	"https://www.macktrucks.com.co/parts-and-services/support/body-builders/news-and-events/",
     language:	"en",
     description:	"Get the latest news from Mack® Trucks Body Builder Portal."
   },

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 Fix #<gh-issue-id>
 
 Test URLs:
-- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
-- After: https://<branch>--vg-macktrucks-com--hlxsites.hlx.page/
+- Before: https://main--vg-macktrucks-com-co--hlxsites.hlx.page/
+- After: https://<branch>--vg-macktrucks-com-co--hlxsites.hlx.page/

--- a/.github/workflows/generate-atom-news-feeds.yaml
+++ b/.github/workflows/generate-atom-news-feeds.yaml
@@ -22,7 +22,7 @@ jobs:
         # The bot user https://github.com/hlx-macktrucks-bot is used to commit the changes. The personal access token
         # must be created from: https://github.com/settings/tokens
         # The token is then stored in the secrets of the this.
-        # see https://github.com/hlxsites/vg-macktrucks-com/settings/secrets/actions
+        # see https://github.com/hlxsites/vg-macktrucks-com-co/settings/secrets/actions
         token: ${{ secrets.BOT_ACCESS_TOKEN }}
     - name: Configure git
       run: |

--- a/404.html
+++ b/404.html
@@ -69,7 +69,7 @@
         <li>Make sure the web address has been entered correctly</li>
         <li>Go <a title="Go back" onclick="history.go(-1)" href="#"><b>BACK</b></a> to the previous page</li>
         <li>Visit the <a title="Home page" href="/"><b>MACK HOMEPAGE</b></a></li>
-        <li>Search the MackTrucks.com site (search box above)</li>
+        <li>Search the MackTrucks.com.co site (search box above)</li>
       </ul>
     </div>
   </main>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Mack Trucks
-Franklin site redesign for macktrucks.com
+Franklin site redesign for macktrucks.com.co
 
 ## Environments
-- Preview: https://main--vg-macktrucks-com--hlxsites.hlx.page/
-- Live: https://main--vg-macktrucks-com--hlxsites.hlx.live/
+- Preview: https://main--vg-macktrucks-com-co--hlxsites.hlx.page/
+- Live: https://main--vg-macktrucks-com-co--hlxsites.hlx.live/
 
 ## Installation
 

--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -5,7 +5,7 @@ export default function decorate(block) {
 
   const articleUrl = (window.location.href).split('/').pop();
   const articleName = articleUrl.replaceAll('-', ' ').toLowerCase();
-  const homeUrl = 'https://www.macktrucks.com/magazine/';
+  const homeUrl = 'https://www.macktrucks.com.co/magazine/';
 
   breadcrumbItems.innerHTML = `
     <li class="breadcrumb breadcrumb-home">

--- a/blocks/eloqua-form/forms/buy-mack-request-a-quote.html
+++ b/blocks/eloqua-form/forms/buy-mack-request-a-quote.html
@@ -1697,7 +1697,7 @@
       type="hidden"
       name="hiddenField"
       id="fe2238"
-      value="Fast Track Form - macktrucks.com - Request a Quote"
+      value="Fast Track Form - macktrucks.com.co - Request a Quote"
     /><input
       type="hidden"
       name="utmsource"

--- a/blocks/eloqua-form/forms/contact-us.html
+++ b/blocks/eloqua-form/forms/contact-us.html
@@ -1336,7 +1336,7 @@
         </div>
       </div>
     </div>
-    <input type="hidden" name="hiddenField" id="fe2713" value="Contact Us - macktrucks.com">
+    <input type="hidden" name="hiddenField" id="fe2713" value="Contact Us - macktrucks.com.co">
   </div>
 </form>
 <script type="text/javascript" src="https://img03.en25.com/i/livevalidation_standalone.compressed.js">

--- a/blocks/eloqua-form/forms/subscribe.html
+++ b/blocks/eloqua-form/forms/subscribe.html
@@ -375,7 +375,7 @@
       <div class="individual field-wrapper" >
         <div class="_100 field-style" >
           <p class="field-p" >
-            <input id="field6" type="hidden" name="hiddenField" value="Subscription Form - macktrucks.com - Email Signup"  />
+            <input id="field6" type="hidden" name="hiddenField" value="Subscription Form - macktrucks.com.co - Email Signup"  />
           </p>
         </div>
       </div>

--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -121,7 +121,7 @@ export default async function decorate(block) {
 
     // Logo
     const logo = createElement('div');
-    const logoLink = createElement('a', { props: { href: 'https://www.macktrucks.com/' } });
+    const logoLink = createElement('a', { props: { href: 'https://www.macktrucks.com.co/' } });
     const svgLogo = document.createRange().createContextualFragment(`
     <svg xmlns="http://www.w3.org/2000/svg" width="193" height="19" viewBox="0 0 193 19">
       <g clip-path="url(#clip0_4707_6556)">

--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,2 @@
 mountpoints:
-  /: https://adobe.sharepoint.com/sites/HelixProjects/Shared%20Documents/sites/VolvoGroup/vg-macktrucks-com
+  /: https://adobe.sharepoint.com/sites/HelixProjects/Shared%20Documents/sites/VolvoGroup/vg-macktrucks-com-co

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -1,5 +1,5 @@
 sitemaps:
   allindex:
-    origin: https://www.macktrucks.com
+    origin: https://www.macktrucks.com.co
     source: /query-index.json
     destination: /sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Disallow:
 
-Sitemap: https://www.macktrucks.com/sitemap.xml
+Sitemap: https://www.macktrucks.com.co/sitemap.xml

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -269,8 +269,8 @@ export function decorateLinks(block) {
       }
 
       const url = new URL(link.href);
-      const external = !url.host.match('macktrucks.com') && !url.host.match('.hlx.(page|live)') && !url.host.match('localhost');
-      if (url.host.match('build.macktrucks.com') || url.pathname.endsWith('.pdf') || external) {
+      const external = !url.host.match('macktrucks.com.co') && !url.host.match('.hlx.(page|live)') && !url.host.match('localhost');
+      if (url.host.match('build.macktrucks.com.co') || url.pathname.endsWith('.pdf') || external) {
         link.target = '_blank';
       }
     });

--- a/tools/fgrep-attr/fgrep.js
+++ b/tools/fgrep-attr/fgrep.js
@@ -12,7 +12,7 @@
 // copied from https://github.com/adobe/express-website/tree/main/tools/fgrep-attr
 
 const gitowner = 'hlxsites';
-const gitrepo = 'vg-macktrucks-com';
+const gitrepo = 'vg-macktrucks-com-co';
 const globalSitemapURL = '/sitemap.xml';
 
 let sitemapURLs = [];

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -5,7 +5,7 @@
       "id": "library",
       "title": "Library",
       "environments": [ "edit" ],
-      "url": "https://main--vg-macktrucks-com--hlxsites.hlx.live/tools/sidekick/library.html",
+      "url": "https://main--vg-macktrucks-com-co--hlxsites.hlx.live/tools/sidekick/library.html",
       "includePaths": [ "**.docx**" ]
     },
     {


### PR DESCRIPTION
# Update
Sync Main .com domain to update Header and Explore blocks

### Header
Hide search and/or Login in other domains than the main one (by now)

### Explore
Make the Explore-trucks tab able to be in any language, but it has to be the 1st H4

#

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://develop--vg-macktrucks-com--hlxsites.hlx.page/
