### PR TITLE
Add assets sidekick plugin

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -13,6 +13,19 @@
       "title": "Search",
       "environments": [ "dev", "preview", "live", "prod" ],
       "url": "/tools/fgrep-attr/fgrep.html"
+    },
+    {
+      "id": "asset-library",
+      "title": "My Assets",
+      "environments": [
+        "edit"
+      ],
+      "url": "https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/franklin/asset-selector.html",
+      "isPalette": true,
+      "includePaths": [
+        "**.docx**"
+      ],
+      "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)"
     }
   ]
 }


### PR DESCRIPTION
For details, please [see this](https://www.aem.live/developer/configuring-aem-assets-sidekick-plugin).

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://assets-plugin--vg-macktrucks-com--hlxsites.hlx.page/
