### PR TITLE
#529 icon fix for features page in mobile view

### DIFF
--- a/blocks/hotspots/hotspots.js
+++ b/blocks/hotspots/hotspots.js
@@ -284,7 +284,7 @@ function addMobileTabNavigation(block, title, hotspotAreaId) {
   }
 
   const link = createElement('a', { props: { href: `#${title.textContent}` } });
-  link.textContent = title.innerHTML;
+  link.innerHTML = title.innerHTML;
   li.append(link);
   mobileNav.firstElementChild.append(li);
 


### PR DESCRIPTION
## Fix

if the features title has a sup element, or not, the element nodes from the Hero header text will be transfer to the buttons at the bottom with the sup element if any

### Test Urls

trucks/anthem/features/
trucks/granite-series/features/

#

### Fix #529

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://529-trucks-features-sup-tag--vg-macktrucks-com--hlxsites.hlx.page/
