### PR TITLE
#560 Remove nav- pages from search

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -114,6 +114,8 @@ indices:
       - '/footer'
       - '/**/nav'
       - '/nav'
+      - '/**/nav-*'
+      - '/nav-*'
       - '/fragments/**'
       - '/**/sub-nav'
       - '/block-library/**'


### PR DESCRIPTION
Fix #560 

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://560-bug-hidden-pages-with-nofollow--vg-macktrucks-com--hlxsites.hlx.page/
