### PR TITLE
#597 New block: Navigation Hub

### DIFF
--- a/blocks/v2-navigation-hub/v2-navigation-hub.css
+++ b/blocks/v2-navigation-hub/v2-navigation-hub.css
@@ -1,0 +1,94 @@
+.v2-navigation-hub-container {
+  --section-padding-top: 0;
+  --section-padding-bottom: 0;
+}
+
+.v2-navigation-hub-wrapper {
+  --card-background: var(--c-primary-gray);
+  --card-secondary-bg: var(--c-secondary-silver);
+}
+
+.v2-navigation-hub {
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto;
+  position: relative;
+  max-width: 1440px;
+}
+
+.v2-navigation-hub__media-container {
+  background-color: var(--card-background);
+  order: 1;
+}
+
+.v2-navigation-hub__card-container {
+  background-color: var(--card-background);
+  order: 2;
+}
+
+.v2-navigation-hub__card-content,
+.v2-navigation-hub__card-navigation {
+  padding: 24px 16px;
+}
+
+.v2-navigation-hub__card-nav-title,
+.v2-navigation-hub__card-content h2 {
+  margin: 0 0 24px;
+}
+
+.v2-navigation-hub__card-content .button-container {
+  margin: 41px 0 0;
+}
+
+.v2-navigation-hub__card-content .button-container a {
+  margin: 0;
+}
+
+.v2-navigation-hub__card-navigation {
+  background-color: var(--card-secondary-bg);
+}
+
+.v2-navigation-hub__card-nav-title {
+  font-family: var(--ff-body-bold);
+  text-transform: uppercase;
+  color: var(--c-tertiary-cool-gray);
+  font-size: 12px;
+  line-height: 16px;
+  letter-spacing: 0.16em;
+}
+
+.v2-navigation-hub__card-nav-list {
+  display: grid;
+  gap: 16px 20px;
+}
+
+@media (min-width: 568px) {
+  .v2-navigation-hub__card-nav-list {
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(3, 1fr);
+    grid-auto-flow: column;
+    max-width: 568px;
+  }
+
+  .v2-navigation-hub__card-nav-list li:nth-child(-n+3) {
+    grid-column: 1;
+  }
+
+  .v2-navigation-hub__card-nav-list li:nth-child(n+4) {
+    grid-column: 2;
+  }
+}
+
+.v2-navigation-hub__card-nav-list a:any-link {
+  align-items: flex-start;
+}
+
+.v2-navigation-hub__card-nav-list .icon {
+  stroke: currentcolor;
+}
+
+.v2-navigation-hub__card-nav-list .icon,
+.v2-navigation-hub__card-nav-list .icon svg {
+  width: 16px;
+  height: 16px;
+}

--- a/blocks/v2-navigation-hub/v2-navigation-hub.js
+++ b/blocks/v2-navigation-hub/v2-navigation-hub.js
@@ -1,0 +1,41 @@
+import { unwrapDivs, variantsClassesToBEM } from '../../scripts/common.js';
+
+const blockName = 'v2-navigation-hub';
+const variantClasses = ['media-left', 'media-right', 'overlap'];
+const blockNames = {
+  card: `${blockName}__card-container`,
+  cardContent: `${blockName}__card-content`,
+  cardNavigation: `${blockName}__card-navigation`,
+  cardNavTitle: `${blockName}__card-nav-title`,
+  cardNavList: `${blockName}__card-nav-list`,
+  media: `${blockName}__media-container`,
+  mediaRight: `${blockName}__media-right`,
+};
+
+export default function decorate(block) {
+  variantsClassesToBEM(block.classList, variantClasses, blockName);
+  const blockWrapper = block.closest(`.${blockName}-wrapper`);
+  // Card elements
+  const cardContainer = block.querySelector(':scope > div:first-child');
+  const cardContent = cardContainer.querySelector(':scope > div:first-child');
+  const cardNavigation = cardContainer.querySelector(':scope > div:last-child');
+  const cardNavTitle = cardNavigation.querySelector(':scope > :first-child');
+  const cardNavList = cardNavigation.querySelector(':scope > ul');
+  const cardNavLinks = [...cardNavList.querySelectorAll('a')];
+  // Media element
+  const mediaContainer = block.querySelector(':scope > div:last-child');
+  // By default, media is on the left side
+  const isMediaLeft = mediaContainer.firstElementChild.children.length > 0;
+
+  blockWrapper.classList.add('full-width');
+  cardContainer.className = blockNames.card;
+  cardContent.className = blockNames.cardContent;
+  cardNavigation.className = blockNames.cardNavigation;
+  cardNavTitle.className = blockNames.cardNavTitle;
+  cardNavList.className = blockNames.cardNavList;
+  cardNavLinks.forEach((link) => { link.className = 'standalone-link'; });
+  mediaContainer.className = blockNames.media;
+  if (!isMediaLeft) mediaContainer.classList.add(blockNames.mediaRight);
+
+  unwrapDivs(mediaContainer);
+}

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -151,6 +151,15 @@ export const removeEmptyTags = (block) => {
   });
 };
 
+/**
+ * This function recursively traverses the child elements of a given element
+ * and removes all <div> elements that have no attributes,
+ * moving their children to the parent element.
+ * @param {HTMLElement} element the parent element to remove its children
+ * @param {Object} options the unwrap options
+ * @param {boolean} [options.ignoreDataAlign=false] whether to ignore divs with data-align attribute
+ * @returns {void}
+ */
 export const unwrapDivs = (element, options = {}) => {
   const stack = [element];
   const { ignoreDataAlign = false } = options;


### PR DESCRIPTION
# What's New

A new block called `Navigation Hub` with 2 variants based on the position in the block configuration file (the Word document) of the image

Also, it will show 2 links columns depending on if the author adds **3** or **6** links. It always will show first a link column with up to 3 elements and then the next up to 3 more links will be in the 2nd column

## Also Adds

add a missing *JSDoc* comment into the `common.js` `unwrapDivs` function to clarify what it does and have it available as an IntelliSense popup.

#

Fix #597

Test URLs:
- Before: https://develop--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://597-image-with-card-block--vg-macktrucks-com--hlxsites.hlx.page/
