### PR TITLE
fix truck-lineup #751

### DIFF
--- a/blocks/v2-truck-lineup/v2-truck-lineup.js
+++ b/blocks/v2-truck-lineup/v2-truck-lineup.js
@@ -10,6 +10,7 @@ import {
 } from '../../scripts/carousel-helper.js';
 
 const blockName = 'v2-truck-lineup';
+const tabContentClass = `.${blockName}__content`;
 
 function stripEmptyTags(main, child) {
   if (child !== main && child.innerHTML.trim() === '') {
@@ -71,8 +72,8 @@ function buildTabNavigation(tabItems, clickHandler) {
       }, 600);
     });
 
-    const tabContent = tabItem.querySelector(':scope > div');
-    const icon = tabContent.dataset.truckCarouselIcon;
+    const tabContent = tabItem.querySelector(tabContentClass);
+    const icon = tabContent && tabContent?.dataset.truckCarouselIcon;
     const svgIcon = icon ? `<span class="icon icon-${icon}"></span>` : '';
     button.innerHTML = `${tabContent.dataset.truckCarousel}${svgIcon}`;
     listItem.append(button);
@@ -164,8 +165,8 @@ export default async function decorate(block) {
 
   tabItems.forEach((tabItem) => {
     tabItem.classList.add(`${blockName}__desc-item`);
-    const tabContent = tabItem.querySelector(':scope > div');
-    const headings = tabContent.querySelectorAll('h1, h2, h3, h4, h5, h6');
+    const tabContent = tabItem.querySelector(tabContentClass);
+    const headings = tabContent ? tabContent.querySelectorAll('h1, h2, h3, h4, h5, h6') : [];
     [...headings].forEach((heading) => heading.classList.add(`${blockName}__title`));
 
     // create div for image and append inside image div container


### PR DESCRIPTION
# Fix

The truck lineup is broken because v5 is adding to the markup a `p` element, so the selector `:scope > div` doesn't work because it has a `p` element in the middle. But because the div already has a class ended in `__content`, I updated the selector to be more specific to fix it.

tested first in the Syb's test [hompage](https://714-spike-helix-v5--vg-macktrucks-com--hlxsites.hlx.page/drafts/syb/page/homepage). Its branch is the spike, my branch is based in develop one

#

### Fix #751

Test URLs:
- Before: https://714-spike-helix-v5--vg-macktrucks-com--hlxsites.hlx.page/drafts/syb/page/homepage
- After: https://751-v2-truck-lineup-broken--vg-macktrucks-com--hlxsites.hlx.page/drafts/syb/page/homepage
