### PR TITLE
v5 aem.js loadCSS returns a promise

### DIFF
--- a/common/modal/modal-component.js
+++ b/common/modal/modal-component.js
@@ -35,10 +35,6 @@ class VideoComponent {
   }
 }
 
-const styles$ = new Promise((r) => {
-  loadCSS(`${window.hlx.codeBasePath}/common/modal/modal-component.css`, r);
-});
-
 const HIDE_MODAL_CLASS = 'modal-hidden';
 
 const createModal = () => {
@@ -79,22 +75,7 @@ const createModal = () => {
   };
 
   async function showModal(newContent, { beforeBanner, beforeIframe, classes = [] } = {}) {
-    await styles$;
-    await new Promise((resolve) => {
-      // because the styles$ is based on the on load event it's waiting for the file to be loaded
-      // but it is not waiting for the style to be applied
-      // (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#stylesheet_load_events)
-      // here were check if the styles are already applied by checking the calculated styles
-      // for one of the element
-      const interval = setInterval(() => {
-        const modalBackgroundStyles = window.getComputedStyle(modalBackground);
-        // the position should be set to 'fixed' by modal css file
-        if (modalBackgroundStyles.getPropertyValue('position') === 'fixed') {
-          clearInterval(interval);
-          resolve();
-        }
-      }, 100);
-    });
+    await loadCSS(`${window.hlx.codeBasePath}/common/modal/modal-component.css`);
     modalBackground.style = '';
     window.addEventListener('keydown', keyDownAction);
 


### PR DESCRIPTION
# Bug Fix

The new helix v5 has changed how the function `loadCSS` works. Now is returning a promise. So it's no longer necessary to enclose the function into a promise or wait if it's applied.

## Test instrucctions

The "_After_" branch is based on `main` branch, so that's why the "_Before_" is the spike's one. play a bit first in the spike and copy this solution into there to test it

#

### Fix #752 

Test URLs:
- Before: https://714-spike-helix-v5--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://752-modal-broken-with-helix-5--vg-macktrucks-com--hlxsites.hlx.page/

Also for testimonial video modals
- Before: https://714-spike-helix-v5--vg-macktrucks-com--hlxsites.hlx.page/drafts/syb/block/v2-testimonial-video
- After: https://752-modal-broken-with-helix-5--vg-macktrucks-com--hlxsites.hlx.page/drafts/syb/block/v2-testimonial-video
