### PR TITLE
add specific styles for with-dots variant & a bit of clean up #779

### DIFF
--- a/blocks/v2-product-listing/v2-product-listing.css
+++ b/blocks/v2-product-listing/v2-product-listing.css
@@ -96,6 +96,7 @@
 }
 
 .v2-product-listing__product-info h2 {
+  font-family: var(--ff-subheadings-medium);
   margin: 0;
   line-height: 1.15;
 }
@@ -109,6 +110,10 @@
   width: 100%;
   display: flex;
   gap: 16px;
+}
+
+.v2-product-listing--with-dots .v2-product-listing__button-container {
+  margin-top: 12px; /* 12 + 12 = 24px to match design */
 }
 
 .v2-product-listing__button-container a.button {
@@ -152,6 +157,7 @@
 }
 
 .v2-product-listing--with-dots .v2-product-listing__detail-list {
+  gap: 12px;
   text-transform: capitalize;
   flex-direction: column;
 }
@@ -261,15 +267,25 @@
   }
 
   .v2-product-listing__product {
+    --v2-product-listing-content-height: 387px;
+
     margin: auto;
     padding: 0;
-    height: 400px;
+    height: var(--v2-product-listing-content-height);
     max-width: 1440px;
     flex-direction: row;
   }
 
+  .v2-product-listing--with-dots .v2-product-listing__product {
+    --v2-product-listing-content-height: 400px;
+  }
+
   .v2-product-listing .v2-product-listing__product:first-of-type {
     padding-top: 0;
+  }
+
+  .v2-product-listing--with-dots .v2-product-listing__product-info h2 {
+    font-size: var(--headline-1-font-size);
   }
 
   .v2-product-listing__product-info > p {
@@ -346,8 +362,16 @@
     align-content: center;
   }
 
+  .v2-product-listing--with-dots .v2-product-listing__product-info {
+    gap: 32px;
+  }
+
   .v2-product-listing__detail-list li {
     line-height: var(--body-1-line-height);
+  }
+
+  .v2-product-listing--with-dots .v2-product-listing__button-container {
+    margin-top: 0; /* using gap instead of margin to match design */
   }
 
   .v2-product-listing__button-container a.button {

--- a/blocks/v2-product-listing/v2-product-listing.css
+++ b/blocks/v2-product-listing/v2-product-listing.css
@@ -429,6 +429,10 @@
     flex: 0 1 var(--v2-product-listing-content-width);
   }
 
+  .v2-product-listing__product-image picture:first-child img {
+    width: 100%;
+  }
+
   .v2-product-listing__product-info {
     flex: 0 1 calc(100% - var(--v2-product-listing-content-width));
     padding: 0 88px 65px;

--- a/blocks/v2-product-listing/v2-product-listing.css
+++ b/blocks/v2-product-listing/v2-product-listing.css
@@ -26,7 +26,7 @@
 }
 
 .v2-product-listing-wrapper {
-  --v2-product-listing-content-gap: 12px;
+  --v2-product-listing-content-gap: 16px;
 
   padding: 0;
 }
@@ -91,13 +91,12 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: var(--v2-product-listing-content-gap);
+  gap: 12px;
   justify-content: center;
 }
 
 .v2-product-listing__product-info h2 {
   margin: 0;
-  font-size: var(--headline-1-font-size);
   line-height: 1.15;
 }
 
@@ -106,7 +105,7 @@
 }
 
 .v2-product-listing__button-container {
-  margin-top: 12px;
+  margin-top: 4px; /* 4 + 12 = 16px to match design */
   width: 100%;
   display: flex;
   gap: 16px;
@@ -148,7 +147,7 @@
 }
 
 .v2-product-listing__detail-list {
-  gap: 12px;
+  gap: 16px;
   align-items: flex-start;
 }
 
@@ -163,7 +162,7 @@
 
   display: flex;
   flex-flow: row wrap;
-  gap: 12px;
+  gap: var(--v2-product-listing-content-gap);
   font-size: var(--v2-product-listing-info-font-size);
 }
 
@@ -173,6 +172,7 @@
 
 .v2-product-listing--with-dots .v2-product-listing__detail-list li {
   --v2-product-listing-info-font-size: var(--body-1-font-size);
+  --v2-product-listing-content-gap: 12px;
 }
 
 .v2-product-listing:not(.v2-product-listing--with-dots) .v2-product-listing__detail-list li:not(:last-child)::after {
@@ -256,8 +256,6 @@
 
 @media (min-width: 744px) {
   .v2-product-listing-wrapper {
-    --v2-product-listing-content-gap: 24px;
-
     margin: auto;
     position: relative;
   }

--- a/blocks/v2-product-listing/v2-product-listing.css
+++ b/blocks/v2-product-listing/v2-product-listing.css
@@ -109,7 +109,7 @@
   margin-top: 4px; /* 4 + 12 = 16px to match design */
   width: 100%;
   display: flex;
-  gap: 16px;
+  gap: var(--v2-product-listing-content-gap);
 }
 
 .v2-product-listing--with-dots .v2-product-listing__button-container {
@@ -152,12 +152,13 @@
 }
 
 .v2-product-listing__detail-list {
-  gap: 16px;
+  gap: var(--v2-product-listing-content-gap);
   align-items: flex-start;
 }
 
 .v2-product-listing--with-dots .v2-product-listing__detail-list {
-  gap: 12px;
+  --v2-product-listing-content-gap: 12px;
+
   text-transform: capitalize;
   flex-direction: column;
 }

--- a/blocks/v2-product-listing/v2-product-listing.css
+++ b/blocks/v2-product-listing/v2-product-listing.css
@@ -95,6 +95,10 @@
   justify-content: center;
 }
 
+.v2-product-listing--with-dots .v2-product-listing__product-info {
+  padding: 24px 16px 64px;
+}
+
 .v2-product-listing__product-info h2 {
   font-family: var(--ff-subheadings-medium);
   font-size: var(--headline-1-font-size);
@@ -120,6 +124,10 @@
 .v2-product-listing__button-container a.button {
   flex: 0 1 50%;
   margin: 0;
+}
+
+.v2-product-listing--with-dots .v2-product-listing__button-container a.button {
+  flex: none;
 }
 
 .v2-product-listing__detail-list,

--- a/blocks/v2-product-listing/v2-product-listing.css
+++ b/blocks/v2-product-listing/v2-product-listing.css
@@ -117,14 +117,6 @@
   margin: 0;
 }
 
-.v2-product-listing__button-container .button--primary {
-  margin-right: 8px;
-}
-
-.v2-product-listing__button-container .button--secondary {
-  margin-left: 8px;
-}
-
 .v2-product-listing__detail-list,
 .v2-product-listing__segment-list {
   list-style: none;
@@ -137,7 +129,7 @@
   position: relative;
   font-size: var(--superscript-font-size);
   line-height: 1.2;
-  letter-spacing: .1em;
+  letter-spacing: 0.1em;
 }
 
 .v2-product-listing__segment-list li:first-child {
@@ -145,7 +137,7 @@
 }
 
 .v2-product-listing__segment-list li::after {
-  content: '';
+  content: "";
   display: block;
   position: absolute;
   right: 0;
@@ -156,25 +148,39 @@
 }
 
 .v2-product-listing__detail-list {
-  text-transform: capitalize;
   gap: 12px;
-  flex-direction: column;
   align-items: flex-start;
+}
+
+.v2-product-listing--with-dots .v2-product-listing__detail-list {
+  text-transform: capitalize;
+  flex-direction: column;
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
 .v2-product-listing__detail-list li {
+  --v2-product-listing-info-font-size: 12px;
+
   display: flex;
   flex-flow: row wrap;
   gap: 12px;
+  font-size: var(--v2-product-listing-info-font-size);
 }
 
 .v2-product-listing__detail-list li strong {
   font-family: var(--ff-body-bold);
 }
 
+.v2-product-listing--with-dots .v2-product-listing__detail-list li {
+  --v2-product-listing-info-font-size: var(--body-1-font-size);
+}
+
+.v2-product-listing:not(.v2-product-listing--with-dots) .v2-product-listing__detail-list li:not(:last-child)::after {
+  content: "|";
+}
+
 .v2-product-listing--with-dots .v2-product-listing__product-image picture:first-child::before {
-  content: '';
+  content: "";
   height: 70%;
   max-height: 275px;
   aspect-ratio: 1;
@@ -182,7 +188,7 @@
   left: 0;
   z-index: 1;
   background: var(--c-primary-gold);
-  mask: url('/media/dots.svg');
+  mask: url("/media/dots.svg");
   transition: background var(--duration-small) var(--easing-standard);
 }
 
@@ -269,7 +275,7 @@
   }
 
   .v2-product-listing__product-info > p {
-    letter-spacing: .01em;
+    letter-spacing: 0.01em;
     text-wrap: balance;
   }
 
@@ -316,7 +322,7 @@
 
   .v2-product-listing__segment-button::after {
     bottom: 0;
-    content: '';
+    content: "";
     display: block;
     height: 4px;
     position: absolute;
@@ -343,7 +349,6 @@
   }
 
   .v2-product-listing__detail-list li {
-    font-size: var(--body-1-font-size);
     line-height: var(--body-1-line-height);
   }
 

--- a/blocks/v2-product-listing/v2-product-listing.css
+++ b/blocks/v2-product-listing/v2-product-listing.css
@@ -97,6 +97,7 @@
 
 .v2-product-listing__product-info h2 {
   font-family: var(--ff-subheadings-medium);
+  font-size: var(--headline-1-font-size);
   margin: 0;
   line-height: 1.15;
 }
@@ -285,6 +286,10 @@
     padding-top: 0;
   }
 
+  .v2-product-listing__product-info h2 {
+    font-size: var(--headline-2-font-size);
+  }
+
   .v2-product-listing--with-dots .v2-product-listing__product-info h2 {
     font-size: var(--headline-1-font-size);
   }
@@ -359,12 +364,14 @@
 
   .v2-product-listing__product-info {
     flex: 0.5 1 50%;
-    padding: 0 16px 0 32px;
-    align-content: center;
+    padding: 0 16px 65px 32px;
+    justify-content: flex-end;
   }
 
   .v2-product-listing--with-dots .v2-product-listing__product-info {
     gap: 32px;
+    padding: 0 16px 0 32px;
+    justify-content: center;
   }
 
   .v2-product-listing__detail-list li {
@@ -391,6 +398,14 @@
 }
 
 @media (min-width: 1200px) {
+  .v2-product-listing__product {
+    --v2-product-listing-content-width: 800px;
+  }
+
+  .v2-product-listing--with-dots .v2-product-listing__product {
+    --v2-product-listing-content-width: 700px;
+  }
+
   .v2-product-listing--with-dots .v2-product-listing__product-image picture:first-child::before {
     margin-left: unset;
   }
@@ -403,11 +418,15 @@
   }
 
   .v2-product-listing__product-image {
-    flex: 0 1 800px;
+    flex: 0 1 var(--v2-product-listing-content-width);
   }
 
   .v2-product-listing__product-info {
-    flex: 0 1 calc(100% - 800px);
+    flex: 0 1 calc(100% - var(--v2-product-listing-content-width));
+    padding: 0 88px 65px;
+  }
+
+  .v2-product-listing--with-dots .v2-product-listing__product-info {
     padding: 40px 88px;
   }
 

--- a/blocks/v2-product-listing/v2-product-listing.css
+++ b/blocks/v2-product-listing/v2-product-listing.css
@@ -69,6 +69,9 @@
   position: relative;
   top: 0;
   left: 0;
+  aspect-ratio: 1 / 1;
+  object-fit: contain;
+  width: 100%;
 }
 
 .v2-product-listing__product picture:first-child img:hover {
@@ -324,6 +327,12 @@
     height: 100%;
     position: absolute;
     top: 0;
+  }
+
+  .v2-product-listing__product-image picture:first-child img {
+    aspect-ratio: auto;
+    object-fit: fill;
+    width: auto;
   }
 
   .v2-product-listing__product-image picture:first-child img,

--- a/blocks/v2-product-listing/v2-product-listing.js
+++ b/blocks/v2-product-listing/v2-product-listing.js
@@ -7,8 +7,8 @@ import {
   variantsClassesToBEM,
 } from '../../scripts/common.js';
 
-// Define break point/s
 const blockName = 'v2-product-listing';
+const variantClasses = ['with-filter', 'with-dots'];
 
 function getActiveFilterButton() {
   const AllFilterButtons = document.querySelectorAll(`.${blockName}__button-list .${blockName}__segment-button`);
@@ -80,7 +80,9 @@ function buildProductInfoDom(prodEle) {
     info.classList.add(`${blockName}__product-info`);
 
     [...buttons].forEach((b) => {
+      const parent = b.parentElement;
       buttonContainer.appendChild(b);
+      parent.remove(); // Remove the previous empty button container
     });
     info.appendChild(buttonContainer);
 
@@ -194,7 +196,6 @@ function handleListeners(dropdownWrapper) {
 }
 
 export default function decorate(block) {
-  const variantClasses = ['with-filter', 'with-dots'];
   variantsClassesToBEM(block.classList, variantClasses, blockName);
 
   const productElement = block.querySelectorAll(`.${blockName} > div`);

--- a/blocks/v2-product-listing/v2-product-listing.js
+++ b/blocks/v2-product-listing/v2-product-listing.js
@@ -81,6 +81,7 @@ function buildProductInfoDom(prodEle) {
 
     [...buttons].forEach((b) => {
       const parent = b.parentElement;
+      b.classList.add('button--large');
       buttonContainer.appendChild(b);
       parent.remove(); // Remove the previous empty button container
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/helix-project-boilerplate",
   "private": true,
-  "version": "19",
+  "version": "20",
   "description": "Starter project for Adobe Helix",
   "scripts": {
     "test": "wtr \"./test/**/*.test.js\" --node-resolve --port=2000 --coverage",


### PR DESCRIPTION
# Fix Updates

I split styling for the `default` and the `with-dots` variant

## Notes

In the Library I had to add a disclaimer note to check if the variant has links in each row, if not it has to be added after copying it.
Also, I didn't test it for the `with-filter` variant, so if it is also affected then we will need to raise a new ticket.

#

Fix #779

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/drafts/jlledo/v2/index-new
- After: https://779-product-listing-padding--vg-macktrucks-com--hlxsites.hlx.page/drafts/jlledo/v2/index-new
