### PR TITLE
fix: workaround for filter options in AEM Assets Sidekick Plugin #791

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -20,7 +20,7 @@
       "environments": [
         "edit"
       ],
-      "url": "https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/franklin/asset-selector.html",
+      "url": "https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/franklin/asset-selector.html?extConfigUrl=https://helix-asset-selector-configs.netlify.app/config.json",
       "isPalette": true,
       "includePaths": [
         "**.docx**"


### PR DESCRIPTION
Fix #791

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://asset-filter-fix--vg-macktrucks-com--hlxsites.hlx.page/
