### PR TITLE
 3 cards variant #594

### DIFF
--- a/blocks/v2-cards/v2-cards.css
+++ b/blocks/v2-cards/v2-cards.css
@@ -41,6 +41,7 @@
   object-fit: cover;
 }
 
+.v2-cards--2-cards-row .v2-cards__image,
 .v2-cards--image-aspect-ratio-7-5 .v2-cards__image {
   aspect-ratio: 7/5;
 }
@@ -146,10 +147,6 @@
 
 .v2-cards.v2-cards--spaced .v2-cards__text-wrapper .v2-cards__button-container {
   margin-top: 12px;
-}
-
-.v2-cards.v2-cards--spaced .v2-cards__image {
-  aspect-ratio: 7/5;
 }
 
 @media (min-width: 744px) {

--- a/blocks/v2-cards/v2-cards.css
+++ b/blocks/v2-cards/v2-cards.css
@@ -62,8 +62,11 @@
   font-family: var(--ff-body);
   font-size: var(--body-1-font-size);
   font-style: normal;
-  line-height: var(--body-1-line-height);
-  letter-spacing: 0.16px;
+}
+
+.v2-cards__text-wrapper li::before {
+  margin-right: 5px;
+  content: url('../../icons/bullet.svg');
 }
 
 .v2-cards__text-wrapper .v2-cards__button-container {
@@ -117,6 +120,38 @@
   stroke-width: 0.1;
 }
 
+/* spaced text variant */
+.v2-cards.v2-cards--spaced .v2-cards__text-wrapper,
+.v2-cards.v2-cards--spaced .v2-cards__text-wrapper ul {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.v2-cards.v2-cards--spaced .v2-cards__heading {
+  font-size: var(--headline-4-font-size);
+  line-height: var(--headline-4-line-height);
+}
+
+.v2-cards.v2-cards--spaced strong {
+  font-family: var(--ff-body-bold);
+}
+
+.v2-cards.v2-cards--spaced .v2-cards__text-wrapper p,
+.v2-cards.v2-cards--spaced .v2-cards__text-wrapper li {
+  display: inline-flex;
+  line-height: 150%;
+  letter-spacing: 0.16px;
+}
+
+.v2-cards.v2-cards--spaced .v2-cards__text-wrapper .v2-cards__button-container {
+  margin-top: 12px;
+}
+
+.v2-cards.v2-cards--spaced .v2-cards__image {
+  aspect-ratio: 7/5;
+}
+
 @media (min-width: 744px) {
   .v2-cards {
     --card-container-gap: 16px;
@@ -155,6 +190,11 @@
 
   .v2-cards--4-cards-row .v2-cards__card-item {
     max-width: calc((100% - 2 * var(--card-container-padding)) / 2);
+  }
+
+  /* 2 cards row variant */
+  .v2-cards--2-cards-row .v2-cards__card-item {
+    max-width: calc((100% - var(--card-container-gap) - 182px) / 2);
   }
 }
 

--- a/blocks/v2-cards/v2-cards.css
+++ b/blocks/v2-cards/v2-cards.css
@@ -41,7 +41,6 @@
   object-fit: cover;
 }
 
-.v2-cards--2-cards-row .v2-cards__image,
 .v2-cards--image-aspect-ratio-7-5 .v2-cards__image {
   aspect-ratio: 7/5;
 }
@@ -121,6 +120,11 @@
 
 .v2-cards--4-cards-row .v2-cards__button-container svg {
   stroke-width: 0.1;
+}
+
+/* 2 cards row variant */
+.v2-cards--2-cards-row .v2-cards__image {
+  aspect-ratio: 7/5;
 }
 
 /* spaced text variant */

--- a/blocks/v2-cards/v2-cards.css
+++ b/blocks/v2-cards/v2-cards.css
@@ -26,6 +26,12 @@
   padding: 24px;
 }
 
+.v2-cards__text-wrapper ul,
+.v2-cards__text-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
 .v2-cards--no-background .v2-cards__text-wrapper {
   padding: 40px 0 0;
 }
@@ -66,6 +72,14 @@
   letter-spacing: 0.16px;
 }
 
+.v2-cards__text-wrapper strong {
+  font-family: var(--ff-body-bold);
+}
+
+.v2-cards__text-wrapper li strong {
+  margin-right: 12px;
+}
+
 .v2-cards__text-wrapper li::before {
   margin-right: 5px;
   content: url('../../icons/bullet.svg');
@@ -97,7 +111,7 @@
 }
 
 .v2-cards--4-cards-row .v2-cards__text-wrapper {
-  padding: 0;
+  padding: 16px 0 0;
 }
 
 .v2-cards--4-cards-row .v2-cards__button-container {
@@ -130,22 +144,12 @@
 /* spaced text variant */
 .v2-cards.v2-cards--spaced .v2-cards__text-wrapper,
 .v2-cards.v2-cards--spaced .v2-cards__text-wrapper ul {
-  display: flex;
-  flex-direction: column;
   gap: 12px;
 }
 
 .v2-cards.v2-cards--spaced .v2-cards__heading {
   font-size: var(--headline-4-font-size);
   line-height: var(--headline-4-line-height);
-}
-
-.v2-cards.v2-cards--spaced strong {
-  font-family: var(--ff-body-bold);
-}
-
-.v2-cards.v2-cards--spaced li strong {
-  margin-right: 12px;
 }
 
 .v2-cards.v2-cards--spaced .v2-cards__text-wrapper p,
@@ -157,6 +161,43 @@
 
 .v2-cards.v2-cards--spaced .v2-cards__text-wrapper .v2-cards__button-container {
   margin-top: 12px;
+}
+
+/* with border variant */
+.v2-cards.v2-cards--with-border .v2-cards__card-item {
+  border: 1px solid var(--c-tertiary-light-cool-gray);
+}
+
+.v2-cards.v2-cards--with-border .v2-cards__image {
+  aspect-ratio: 4/3;
+}
+
+.v2-cards.v2-cards--with-border .v2-cards__text-wrapper {
+  padding: 16px;
+}
+
+.v2-cards.v2-cards--with-border .v2-cards__heading {
+  margin-bottom: 4px;
+} 
+
+.v2-cards.v2-cards--with-border .v2-cards__text-wrapper ul {
+  gap: 8px;
+}
+
+/* with arrow variant */
+.v2-cards.v2-cards--with-arrow .v2-cards__heading {
+  font-size: var(--headline-5-font-size);
+  line-height: var(--headline-5-line-height);
+  width: 100%;
+  display: inline-flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
+.v2-cards.v2-cards--with-arrow .v2-cards__heading::after {
+  height: 28px;
+  width: 28px;
+  content: url('../../icons/arrow-right.svg');
 }
 
 @media (min-width: 744px) {

--- a/blocks/v2-cards/v2-cards.css
+++ b/blocks/v2-cards/v2-cards.css
@@ -192,17 +192,16 @@
   gap: 8px;
 }
 
-/* with arrow variant */
-.v2-cards.v2-cards--with-arrow .v2-cards__heading {
-  font-size: var(--headline-5-font-size);
-  line-height: var(--headline-5-line-height);
+/* heading with link and arrow */
+.v2-cards.v2-cards--heading-with-arrow .v2-cards__heading a {
+  color: var(--text-color);
   width: 100%;
   display: inline-flex;
   justify-content: space-between;
   align-items: flex-end;
 }
 
-.v2-cards.v2-cards--with-arrow .v2-cards__heading::after {
+.v2-cards.v2-cards--heading-with-arrow .v2-cards__heading a::after {
   height: 28px;
   width: 28px;
   content: url('../../icons/arrow-right.svg');

--- a/blocks/v2-cards/v2-cards.css
+++ b/blocks/v2-cards/v2-cards.css
@@ -63,6 +63,8 @@
   font-family: var(--ff-body);
   font-size: var(--body-1-font-size);
   font-style: normal;
+  line-height: var(--body-1-line-height);
+  letter-spacing: 0.16px;
 }
 
 .v2-cards__text-wrapper li::before {
@@ -136,6 +138,10 @@
 
 .v2-cards.v2-cards--spaced strong {
   font-family: var(--ff-body-bold);
+}
+
+.v2-cards.v2-cards--spaced li strong {
+  margin-right: 12px;
 }
 
 .v2-cards.v2-cards--spaced .v2-cards__text-wrapper p,

--- a/blocks/v2-cards/v2-cards.js
+++ b/blocks/v2-cards/v2-cards.js
@@ -2,7 +2,15 @@ import { variantsClassesToBEM } from '../../scripts/common.js';
 
 export default async function decorate(block) {
   const blockName = 'v2-cards';
-  const variantClasses = ['no-background', 'horizontal', 'image-aspect-ratio-7-5', 'large-heading', '4-cards-row'];
+  const variantClasses = [
+    'no-background',
+    'horizontal',
+    'image-aspect-ratio-7-5',
+    'large-heading',
+    '4-cards-row',
+    '2-cards-row',
+    'spaced',
+  ];
   variantsClassesToBEM(block.classList, variantClasses, blockName);
 
   const cardsItems = [...block.querySelectorAll(':scope > div')];
@@ -36,6 +44,9 @@ export default async function decorate(block) {
         link.classList.add('button--small');
       } else {
         link.classList.add('standalone-link', `${blockName}__button`);
+      }
+      if (block.classList.contains(`${blockName}--spaced`)) {
+        link.classList.replace('button--small', 'button--large');
       }
     });
   });

--- a/blocks/v2-cards/v2-cards.js
+++ b/blocks/v2-cards/v2-cards.js
@@ -10,7 +10,7 @@ export default async function decorate(block) {
     '4-cards-row',
     '2-cards-row',
     'spaced',
-    'with-arrow',
+    // 'with-arrow',
     'with-border',
   ];
   variantsClassesToBEM(block.classList, variantClasses, blockName);
@@ -34,7 +34,10 @@ export default async function decorate(block) {
   images.forEach((el) => el.classList.add(`${blockName}__image`));
 
   const cardsHeadings = [...block.querySelectorAll('h1, h2, h3, h4, h5, h6')];
-  cardsHeadings.forEach((el) => el.classList.add(`${blockName}__heading`));
+  cardsHeadings.forEach((el) => {
+    el.classList.add(`${blockName}__heading`);
+    if (el.querySelector('a')) block.classList.add(`${blockName}--heading-with-arrow`);
+  });
 
   const buttons = [...block.querySelectorAll('.button-container')];
   buttons.forEach((el) => {

--- a/blocks/v2-cards/v2-cards.js
+++ b/blocks/v2-cards/v2-cards.js
@@ -10,6 +10,8 @@ export default async function decorate(block) {
     '4-cards-row',
     '2-cards-row',
     'spaced',
+    'with-arrow',
+    'with-border',
   ];
   variantsClassesToBEM(block.classList, variantClasses, blockName);
 

--- a/icons/bullet.svg
+++ b/icons/bullet.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="17" viewBox="0 0 16 17" fill="none">
+  <line fill="var(--color-icon, #000)" x1="5" y1="10.0503" x2="11" y2="10.0503" stroke="black" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
Fix #594

Added variants to the `v2-cards` block:
- When adding a link to the heading the arrow appears on the right
-`with border` adds a gray `border` to the card, sets the img to a 4/3 `aspect-ratio` and a `gap` of 8px

Figma link [HERE](https://www.figma.com/design/oNwe2jHIICPMIe551EY62l/Mack-Reskin---Full-Project?node-id=2243-138147&m=dev)

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/drafts/shomps/v2-cards
- After: https://594-3-cards-variant--vg-macktrucks-com--hlxsites.hlx.page/drafts/shomps/v2-cards
