### PR TITLE
Search: Updating the Metadata for Magazine Search (1 of 5) #683

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -103,12 +103,9 @@ indices:
       description:
         select: head > meta[property="og:description"]
         value: attribute(el, "content")
-      category:
-        select: head > meta[name="category"]
-        value: attribute(el, "content")
-      truck:
-        select: head > meta[name="truck"]
-        value: attribute(el, "content")
+      tags:
+        select: head > meta[property="article:tag"]
+        values: attribute(el, "content")
       author:
         select: head > meta[name="author"]
         value: attribute(el, "content")


### PR DESCRIPTION
Fix https://github.com/hlxsites/vg-volvotrucks-us/issues/683

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://683-update-metadata-magazine-search--vg-macktrucks-com--hlxsites.hlx.page/
