### PR TITLE
fix: Fix assets plugin in sidekick config

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -25,7 +25,8 @@
       "includePaths": [
         "**.docx**"
       ],
-      "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)"
+      "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)",
+      "passConfig": true
     }
   ]
 }


### PR DESCRIPTION
Assets addon  plugin config was missing "passConfig" option which resulted in [custom config](https://github.com/hlxsites/vg-macktrucks-com/blob/317eb915ce03632c76a034b3b063f035fde72c1b/tools/assets-selector/config.json) not being read and hence not getting applied.

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://sk-cfg-fix--vg-macktrucks-com--hlxsites.hlx.page/
