### PR TITLE
Revert "766 add magazines metadata to search"

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -172,24 +172,12 @@ indices:
       description:
         select: head > meta[name="description"]
         value: attribute(el, "content")
-      author:
-        select: head > meta[name="author"]
-        value: attribute(el, "content")
       category:
         select: head > meta[name="category"]
         value: attribute(el, "content")
       tags:
         select: head > meta[property="article:tag"]
         values: attribute(el, "content")
-      image:
-        select: head > meta[property="og:image"]
-        value: match(attribute(el, "content"), "https:\/\/[^/]+(/.*)")
-      readTime:
-        select: head > meta[name="readingtime"]
-        value: attribute(el, "content")
-      publishDate:
-        select: head > meta[name="publish-date"]
-        value: parseTimestamp(attribute(el, "content"), MM/DD/YYYY)
       text:
         select: main
         value: textContent(el)


### PR DESCRIPTION

Reverts hlxsites/vg-macktrucks-com#853
Remove new fields due to ingestion issues.
Fix #766

Test URLs:

    Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
    After: https://766-fr-bulldog-magazine-search--vg-macktrucks-com--hlxsites.hlx.page/