### PR TITLE
867 fix search tags

### DIFF
--- a/blocks/explore-articles/explore-articles.js
+++ b/blocks/explore-articles/explore-articles.js
@@ -1,9 +1,10 @@
-import { createElement, getTextLabel } from '../../scripts/common.js';
+import { createElement, getTextLabel, getArticleTagsJSON } from '../../scripts/common.js';
 import { getAllArticles } from '../recent-articles/recent-articles.js';
 
 const allArticles = await getAllArticles();
-const allCategories = [...new Set(allArticles.map((article) => article.category))];
-const allTrucks = [...new Set(allArticles.map((article) => article.truck))];
+const allCategoryTags = await getArticleTagsJSON();
+const allCategories = allCategoryTags.categories;
+const allTrucks = allCategoryTags.trucks;
 
 const [categoryPlaceholder, truckPlaceholder] = getTextLabel('Article filter placeholder').split(',');
 

--- a/blocks/explore-articles/explore-articles.js
+++ b/blocks/explore-articles/explore-articles.js
@@ -2,9 +2,9 @@ import { createElement, getTextLabel, getArticleTagsJSON } from '../../scripts/c
 import { getAllArticles } from '../recent-articles/recent-articles.js';
 
 const allArticles = await getAllArticles();
-const allCategoryTags = await getArticleTagsJSON();
-const allCategories = allCategoryTags.categories;
-const allTrucks = allCategoryTags.trucks;
+const allArticleTags = await getArticleTagsJSON();
+const allCategories = allArticleTags.categories;
+const allTrucks = allArticleTags.trucks;
 
 const [categoryPlaceholder, truckPlaceholder] = getTextLabel('Article filter placeholder').split(',');
 

--- a/blocks/recent-articles/recent-articles.js
+++ b/blocks/recent-articles/recent-articles.js
@@ -2,11 +2,20 @@ import {
   createElement,
   getOrigin,
   getTextLabel,
+  getArticleTagsJSON,
 } from '../../scripts/common.js';
 import { createOptimizedPicture } from '../../scripts/aem.js';
 
 const sectionTitle = getTextLabel('Recent article text');
 const readNowText = getTextLabel('READ NOW');
+const allArticleTags = await getArticleTagsJSON();
+const allCategories = allArticleTags.categories;
+
+const getArticleCategory = (article) => {
+  const articleTags = JSON.parse(article.tags);
+  const articleCategory = articleTags.find((e) => allCategories.includes(e));
+  return articleCategory;
+};
 
 export const getAllArticles = async () => {
   const response = await fetch('/magazine-articles.json');
@@ -64,14 +73,14 @@ export default async function decorate(block) {
       ${pictureTag}
     </a>`;
 
-    // TODO: to be updated if the category is not properly gathered from magazine-articles.json
-    const categoriesWithDash = e.category.replaceAll(' ', '-').toLowerCase();
-    const categoryUrl = new URL(`magazine/categories/${categoriesWithDash}`, getOrigin());
+    const articleCategory = getArticleCategory(e);
+    const categoryWithDash = articleCategory.replaceAll(' ', '-').toLowerCase();
+    const categoryUrl = new URL(`magazine/categories/${categoryWithDash}`, getOrigin());
     const category = createElement('a', {
       classes: `recent-articles-${firstOrRest}-category`,
       props: { href: categoryUrl },
     });
-    category.innerText = e.category;
+    category.innerText = articleCategory;
 
     const title = createElement('a', {
       classes: `recent-articles-${firstOrRest}-title`,

--- a/blocks/recent-articles/recent-articles.js
+++ b/blocks/recent-articles/recent-articles.js
@@ -12,9 +12,15 @@ const allArticleTags = await getArticleTagsJSON();
 const allCategories = allArticleTags.categories;
 
 const getArticleCategory = (article) => {
-  const articleTags = JSON.parse(article.tags);
-  const articleCategory = articleTags.find((e) => allCategories.includes(e));
-  return articleCategory;
+  try {
+    const articleTags = JSON.parse(article.tags);
+    const categoriesSet = new Set(allCategories);
+    return articleTags.find((tag) => categoriesSet.has(tag)) || null;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error parsing article tags:', error);
+    return null;
+  }
 };
 
 export const getAllArticles = async () => {

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -633,9 +633,7 @@ function getValuesFromObjectsArray(array = []) {
   return array.map((item) => Object.values(item)[0]);
 }
 
-async function fetchArticleTagsJSON() {
-  return getJsonFromUrl('/magazine/articles/tags.json');
-}
+const fetchArticleTagsJSON = async () => getJsonFromUrl('/magazine/articles/tags.json');
 
 /**
  * Fetches the tags from the JSON file
@@ -644,15 +642,21 @@ async function fetchArticleTagsJSON() {
  * @property {Array} trucks - An array of trucks
  * @property {Array} topics - An array of topics
  */
-export async function getArticleTagsJSON() {
-  const tagsJSON = await fetchArticleTagsJSON();
-  const tags = {
-    categories: getValuesFromObjectsArray(tagsJSON.categories?.data),
-    trucks: getValuesFromObjectsArray(tagsJSON.trucks?.data),
-    topics: getValuesFromObjectsArray(tagsJSON.topics?.data),
-  };
-  return tags;
-}
+export const getArticleTagsJSON = async () => {
+  try {
+    const tagsJSON = await fetchArticleTagsJSON();
+
+    return {
+      categories: getValuesFromObjectsArray(tagsJSON.categories?.data),
+      trucks: getValuesFromObjectsArray(tagsJSON.trucks?.data),
+      topics: getValuesFromObjectsArray(tagsJSON.topics?.data),
+    };
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching article tags JSON:', error);
+    throw new Error('Unable to fetch article tags.');
+  }
+};
 
 /**
  * Extracts the matching tags from an array of tags and an array of article tags

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -633,6 +633,27 @@ function getValuesFromObjectsArray(array = []) {
   return array.map((item) => Object.values(item)[0]);
 }
 
+async function fetchArticleTagsJSON() {
+  return getJsonFromUrl('/magazine/articles/tags.json');
+}
+
+/**
+ * Fetches the tags from the JSON file
+ * @returns {Object} An object with the tags
+ * @property {Array} categories - An array of categories
+ * @property {Array} trucks - An array of trucks
+ * @property {Array} topics - An array of topics
+ */
+export async function getArticleTagsJSON() {
+  const tagsJSON = await fetchArticleTagsJSON();
+  const tags = {
+    categories: getValuesFromObjectsArray(tagsJSON.categories?.data),
+    trucks: getValuesFromObjectsArray(tagsJSON.trucks?.data),
+    topics: getValuesFromObjectsArray(tagsJSON.topics?.data),
+  };
+  return tags;
+}
+
 /**
  * Extracts the matching tags from an array of tags and an array of article tags
  * and returns a string of matching tags
@@ -659,7 +680,7 @@ function getMetadataFromTags(tags, articleTags) {
  */
 export async function getArticleTags(tagType) {
   const articleTags = document.head.querySelectorAll('meta[property="article:tag"]') || [];
-  const tagItems = await getJsonFromUrl('/magazine/articles/tags.json');
+  const tagItems = await fetchArticleTagsJSON();
   const tags = tagItems && tagItems[tagType]
     && getValuesFromObjectsArray(tagItems[tagType].data);
   return getMetadataFromTags(tags, articleTags);


### PR DESCRIPTION
### Fix update

I added a workaround to fill the categories and trucks from tags.json from the Sharepoint/magazines/articles. As a next step, as soon the new block with the filters will be ready, then instead of this update, it will take the info from the search engine

so in the explore articles page, the two dropdown filters are filled with the json file, and in any article page, the recent-articles block also grabs the category from the same json file

Fix #867

Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/magazine/explore-articles
- After: https://867-fix-search-tags--vg-macktrucks-com--hlxsites.hlx.page/magazine/explore-articles

2nd test
- any other magazine article
