### PR TITLE
Exclude articles with no images from articles lists #828

### DIFF
--- a/blocks/explore-articles/explore-articles.js
+++ b/blocks/explore-articles/explore-articles.js
@@ -1,4 +1,8 @@
-import { createElement, getTextLabel, getArticleTagsJSON } from '../../scripts/common.js';
+import {
+  createElement,
+  getTextLabel,
+  getArticleTagsJSON,
+} from '../../scripts/common.js';
 import { getAllArticles } from '../recent-articles/recent-articles.js';
 
 const allArticles = await getAllArticles();

--- a/blocks/explore-articles/explore-articles.js
+++ b/blocks/explore-articles/explore-articles.js
@@ -3,10 +3,10 @@ import {
   fetchMagazineArticles,
   getArticleTagsJSON,
   removeArticlesWithNoImage,
-} from '../../scripts/magazine-helper.js';
+} from '../../scripts/services/magazine.service.js';
 
 const allArticles = await fetchMagazineArticles();
-removeArticlesWithNoImage(allArticles);
+const allArticlesWithImage = removeArticlesWithNoImage(allArticles);
 const allArticleTags = await getArticleTagsJSON();
 const allCategories = allArticleTags.categories;
 const allTrucks = allArticleTags.trucks;
@@ -187,7 +187,7 @@ const handleForm = () => {
   const selects = fieldset.querySelectorAll('select');
   const [category, truck] = selects;
 
-  const filteredList = allArticles.filter((article) => {
+  const filteredList = allArticlesWithImage.filter((article) => {
     const criteria = [
       category.value === categoryPlaceholder && truck.value === truckPlaceholder,
       category.value === categoryPlaceholder && truck.value === article.truck,
@@ -246,7 +246,7 @@ export default async function decorate(block) {
   headingSection.append(h4Element, text);
   contentSection.append(buildFieldset());
 
-  contentSection.append(buildArticleList(allArticles, 0));
+  contentSection.append(buildArticleList(allArticlesWithImage, 0));
 
   generalSection.append(headingSection, contentSection);
 

--- a/blocks/explore-articles/explore-articles.js
+++ b/blocks/explore-articles/explore-articles.js
@@ -1,14 +1,16 @@
+import { createElement, getTextLabel } from '../../scripts/common.js';
 import {
-  createElement,
-  getTextLabel,
+  fetchMagazineArticles,
   getArticleTagsJSON,
-} from '../../scripts/common.js';
-import { getAllArticles } from '../recent-articles/recent-articles.js';
+  removeArticlesWithNoImage,
+} from '../../scripts/magazine-helper.js';
 
-const allArticles = await getAllArticles();
+const allArticles = await fetchMagazineArticles();
+removeArticlesWithNoImage(allArticles);
 const allArticleTags = await getArticleTagsJSON();
 const allCategories = allArticleTags.categories;
 const allTrucks = allArticleTags.trucks;
+const blockName = 'explore-articles';
 
 const [categoryPlaceholder, truckPlaceholder] = getTextLabel('Article filter placeholder').split(',');
 
@@ -63,36 +65,42 @@ const buildArticle = (e) => {
   });
   articleImage.append(image);
 
-  const category = createElement('a', {
-    classes: 'article-category',
-    props: { href: categoryUrl },
-  });
-  category.innerText = e.category;
+  if (e.category.length !== 0) {
+    const category = createElement('a', {
+      classes: 'article-category',
+      props: { href: categoryUrl },
+    });
+    category.innerText = e.category;
+    articleContent.append(category);
+  }
 
   const link = createElement('a', {
     classes: 'article-link',
     props: { href: linkUrl },
   });
+
   const title = createElement('h3', { classes: 'article-title' });
   title.innerText = e.title;
-  const subtitle = createElement('p', { classes: 'article-subtitle' });
-  subtitle.innerText = e.subtitle;
-
   link.append(title);
-  if (e.subtitle.length !== 0) link.append(subtitle);
 
-  const truck = createElement('div', { classes: 'article-truck' });
-  const truckText = createElement('p', { classes: 'article-truck-text' });
-  truckText.innerText = e.truck;
-  const truckIcon = createElement('img', {
-    classes: 'article-truck-icon',
-    props: { src: '/icons/Truck_Key_icon.svg', alt: 'truck icon' },
-  });
-  truck.append(truckIcon, truckText);
+  if (e.subtitle.length !== 0) {
+    const subtitle = createElement('p', { classes: 'article-subtitle' });
+    subtitle.innerText = e.subtitle;
+    link.append(subtitle);
+  }
+  articleContent.append(link);
 
-  articleContent.append(category, link);
-  if (e.truck.length !== 0) articleContent.append(truck);
-
+  if (e.truck.length !== 0) {
+    const truck = createElement('div', { classes: 'article-truck' });
+    const truckText = createElement('p', { classes: 'article-truck-text' });
+    truckText.innerText = e.truck;
+    const truckIcon = createElement('img', {
+      classes: 'article-truck-icon',
+      props: { src: '/icons/Truck_Key_icon.svg', alt: 'truck icon' },
+    });
+    truck.append(truckIcon, truckText);
+    articleContent.append(truck);
+  }
   article.append(articleImage, articleContent);
   return article;
 };
@@ -151,7 +159,7 @@ const buildArticleList = (articles) => {
   const amountOfGroups = articleGroups.length;
 
   const paginationSection = createElement('div', { classes: 'pagination-section' });
-  const articlesSection = createElement('div', { classes: 'explore-articles-articles' });
+  const articlesSection = createElement('div', { classes: `${blockName}-articles` });
 
   const amountOfArticles = createElement('p', { classes: 'article-amount' });
   amountOfArticles.textContent = (totalArticlesNumber !== 0) ? `${totalArticlesNumber} articles` : getTextLabel('No article Message');
@@ -159,7 +167,7 @@ const buildArticleList = (articles) => {
   paginationSection.append(amountOfArticles);
   articlesSection.append(paginationSection);
 
-  const moreSection = createElement('div', { classes: 'explore-articles-more' });
+  const moreSection = createElement('div', { classes: `${blockName}-more` });
   const moreButton = createElement('button', { classes: 'more-btn' });
   moreButton.textContent = getTextLabel('Load more articles button');
   moreButton.addEventListener('click', (evt) => loadMoreArticles(evt, articleGroups, amountOfGroups));
@@ -194,7 +202,7 @@ const handleForm = () => {
     return null;
   });
 
-  const articleList = document.querySelector('.explore-articles-articles');
+  const articleList = document.querySelector(`.${blockName}-articles`);
 
   articleList.textContent = '';
   const filteredArticles = buildArticleList(filteredList, 0);
@@ -202,7 +210,7 @@ const handleForm = () => {
 };
 
 const buildFieldset = () => {
-  const formSection = createElement('div', { classes: 'explore-articles-fieldset' });
+  const formSection = createElement('div', { classes: `${blockName}-fieldset` });
   const form = createElement('form', ['form', 'filter-list'], { method: 'get', name: 'article-fieldset' });
   form.addEventListener('change', handleForm);
 
@@ -226,14 +234,14 @@ export default async function decorate(block) {
   const children = block.querySelectorAll('p');
   const [title, text] = children;
 
-  const generalSection = createElement('div', { classes: 'explore-articles-section' });
+  const generalSection = createElement('div', { classes: `${blockName}-section` });
 
-  const headingSection = createElement('div', { classes: 'explore-articles-heading' });
-  const contentSection = createElement('div', { classes: 'explore-articles-content' });
+  const headingSection = createElement('div', { classes: `${blockName}-heading` });
+  const contentSection = createElement('div', { classes: `${blockName}-content` });
 
-  const h4Element = createElement('h4', { classes: 'explore-articles-title' });
+  const h4Element = createElement('h4', { classes: `${blockName}-title` });
   h4Element.innerText = title.innerText;
-  text.classList.add('explore-articles-text');
+  text.classList.add(`${blockName}-text`);
 
   headingSection.append(h4Element, text);
   contentSection.append(buildFieldset());

--- a/blocks/recent-articles/recent-articles.js
+++ b/blocks/recent-articles/recent-articles.js
@@ -2,109 +2,83 @@ import {
   createElement,
   getOrigin,
   getTextLabel,
-  getArticleTagsJSON,
 } from '../../scripts/common.js';
+import {
+  fetchMagazineArticles,
+  getArticleTagsJSON,
+  getArticleCategory,
+  extractLimitFromBlock,
+  clearRepeatedArticles,
+  sortArticlesByLastModifiedDate,
+  removeArticlesWithNoImage,
+} from '../../scripts/magazine-helper.js';
 import { createOptimizedPicture } from '../../scripts/aem.js';
 
 const sectionTitle = getTextLabel('Recent article text');
 const readNowText = getTextLabel('READ NOW');
+const defaultLimit = 5;
+const blockName = 'recent-articles';
+
 const allArticleTags = await getArticleTagsJSON();
 const allCategories = allArticleTags.categories;
 
-const getArticleCategory = (article) => {
-  try {
-    const articleTags = JSON.parse(article.tags);
-    const categoriesSet = new Set(allCategories);
-    return articleTags.find((tag) => categoriesSet.has(tag)) || null;
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error('Error parsing article tags:', error);
-    return null;
-  }
-};
-
-export const getAllArticles = async () => {
-  const response = await fetch('/magazine-articles.json');
-  const json = await response.json();
-  return json.data;
-};
-
-export const getLimit = (block) => {
-  const classes = block.classList;
-  let limit;
-  classes.forEach((e) => {
-    const [name, value] = e.split('-');
-    if (name === 'limit') limit = value;
-  });
-  return limit;
-};
-
-export const clearRepeatedArticles = (articles) => articles.filter((e) => {
-  const currentArticlePath = window.location.href.split('/').pop();
-  const path = e.path.split('/').pop();
-  if (path !== currentArticlePath) return e;
-  return null;
-});
-
-export const sortArticles = (articles) => articles.sort((a, b) => {
-  a.lastModified = +(a.lastModified);
-  b.lastModified = +(b.lastModified);
-  return b.lastModified - a.lastModified;
-});
-
 export default async function decorate(block) {
-  const limit = Number(getLimit(block));
-  const allArticles = await getAllArticles();
+  const limit = extractLimitFromBlock(block) || defaultLimit;
+  const allArticles = await fetchMagazineArticles();
 
-  const sortedArticles = sortArticles(allArticles);
+  removeArticlesWithNoImage(allArticles);
+  const sortedArticles = sortArticlesByLastModifiedDate(allArticles);
   const filteredArticles = clearRepeatedArticles(sortedArticles);
   const selectedArticles = filteredArticles.slice(0, limit);
 
-  const recentArticlesSection = createElement('div', { classes: 'recent-articles-section' });
-  const recentArticlesTitle = createElement('h3', { classes: 'recent-articles-section-title' });
+  const recentArticlesSection = createElement('div', { classes: `${blockName}-section` });
+  const recentArticlesTitle = createElement('h3', { classes: `${blockName}-section-title` });
   recentArticlesTitle.innerText = sectionTitle;
 
-  const recentArticleList = createElement('ul', { classes: 'recent-articles-list' });
+  const recentArticleList = createElement('ul', { classes: `${blockName}-list` });
 
   selectedArticles.forEach((e, idx) => {
     const linkUrl = new URL(e.path, getOrigin());
     const firstOrRest = (idx === 0) ? 'first' : 'rest';
 
-    const item = createElement('li', { classes: `recent-articles-${firstOrRest}-item` });
+    const item = createElement('li', { classes: `${blockName}-${firstOrRest}-item` });
 
-    const image = createElement('div', { classes: `recent-articles-${firstOrRest}-image` });
+    const image = createElement('div', { classes: `${blockName}-${firstOrRest}-image` });
     const picture = createOptimizedPicture(e.image, e.title);
     const pictureTag = picture.outerHTML;
     image.innerHTML = `<a href='${linkUrl}'>
       ${pictureTag}
     </a>`;
 
-    const articleCategory = getArticleCategory(e);
-    const categoryWithDash = articleCategory.replaceAll(' ', '-').toLowerCase();
-    const categoryUrl = new URL(`magazine/categories/${categoryWithDash}`, getOrigin());
-    const category = createElement('a', {
-      classes: `recent-articles-${firstOrRest}-category`,
-      props: { href: categoryUrl },
-    });
-    category.innerText = articleCategory;
-
     const title = createElement('a', {
-      classes: `recent-articles-${firstOrRest}-title`,
+      classes: `${blockName}-${firstOrRest}-title`,
       props: { href: linkUrl },
     });
     title.innerText = e.title;
 
-    const subtitle = createElement('p', { classes: `recent-articles-${firstOrRest}-subtitle` });
+    const subtitle = createElement('p', { classes: `${blockName}-${firstOrRest}-subtitle` });
     subtitle.innerText = e.subtitle;
 
     const link = createElement('a', {
-      classes: `recent-articles-${firstOrRest}-link`,
+      classes: `${blockName}-${firstOrRest}-link`,
       props: { href: linkUrl },
     });
     link.innerText = readNowText;
 
     if (idx === 0) {
-      item.append(image, category, title, subtitle, link);
+      item.append(image);
+      const articleCategory = getArticleCategory(e, allCategories);
+      if (articleCategory) {
+        const categoryWithDash = articleCategory.replaceAll(' ', '-').toLowerCase();
+        const categoryUrl = new URL(`magazine/categories/${categoryWithDash}`, getOrigin());
+        const category = createElement('a', {
+          classes: `${blockName}-${firstOrRest}-category`,
+          props: { href: categoryUrl },
+        });
+        category.innerText = articleCategory;
+        item.append(category);
+      }
+      item.append(title, subtitle, link);
     } else {
       item.append(image, title);
     }

--- a/blocks/recent-articles/recent-articles.js
+++ b/blocks/recent-articles/recent-articles.js
@@ -11,7 +11,7 @@ import {
   clearRepeatedArticles,
   sortArticlesByLastModifiedDate,
   removeArticlesWithNoImage,
-} from '../../scripts/magazine-helper.js';
+} from '../../scripts/services/magazine.service.js';
 import { createOptimizedPicture } from '../../scripts/aem.js';
 
 const sectionTitle = getTextLabel('Recent article text');
@@ -26,8 +26,8 @@ export default async function decorate(block) {
   const limit = extractLimitFromBlock(block) || defaultLimit;
   const allArticles = await fetchMagazineArticles();
 
-  removeArticlesWithNoImage(allArticles);
-  const sortedArticles = sortArticlesByLastModifiedDate(allArticles);
+  const allArticlesWithImage = removeArticlesWithNoImage(allArticles);
+  const sortedArticles = sortArticlesByLastModifiedDate(allArticlesWithImage);
   const filteredArticles = clearRepeatedArticles(sortedArticles);
   const selectedArticles = filteredArticles.slice(0, limit);
 

--- a/blocks/recommendations/recommendations.css
+++ b/blocks/recommendations/recommendations.css
@@ -102,17 +102,18 @@
   .recommendations-container {
     width: 100%;
   }
-  
+
   .recommendations-list {
     flex-direction: row;
     justify-content: flex-start;
     column-gap: 15px;
   }
-  
+
   .recommendations-item {
     --card-height: 270px;
 
-    width: 50%;
+    width: 100%;
+    min-width: 50%;
   }
 }
 
@@ -121,16 +122,26 @@
   margin: unset;
 }
 
-.magazine-categories.recommendations-container .recommendations-text-content .recommendations-title,
-.magazine-categories.recommendations-container .recommendations-text-content .recommendations-subtitle,
-.magazine-categories.recommendations-container .recommendations-text-content .recommendations-link,
-.magazine-categories.recommendations-container .recommendations-text-content .recommendations-truck {
+.magazine-categories.recommendations-container
+  .recommendations-text-content
+  .recommendations-title,
+.magazine-categories.recommendations-container
+  .recommendations-text-content
+  .recommendations-subtitle,
+.magazine-categories.recommendations-container
+  .recommendations-text-content
+  .recommendations-link,
+.magazine-categories.recommendations-container
+  .recommendations-text-content
+  .recommendations-truck {
   display: flex;
   color: var(--c-primary-black);
   line-height: 22px;
 }
 
-.magazine-categories.recommendations-container .recommendations-text-content .recommendations-category,
+.magazine-categories.recommendations-container
+  .recommendations-text-content
+  .recommendations-category,
 .magazine-categories.recommendations-container .recommendations-section-title {
   display: none;
 }
@@ -159,41 +170,56 @@
   padding: 10px 0 20px;
 }
 
-.magazine-categories.recommendations-container .recommendations-text-content a:hover {
+.magazine-categories.recommendations-container
+  .recommendations-text-content
+  a:hover {
   text-decoration: 0;
   color: var(--c-secondary-steel);
 }
 
-.magazine-categories.recommendations-container .recommendations-text-content .recommendations-title {
+.magazine-categories.recommendations-container
+  .recommendations-text-content
+  .recommendations-title {
   font-family: var(--ff-body-bold);
   font-size: var(--heading-font-size-s);
   margin: 5px 0 0;
   padding: 0 0 5px;
 }
 
-.magazine-categories.recommendations-container .recommendations-text-content .recommendations-subtitle {
+.magazine-categories.recommendations-container
+  .recommendations-text-content
+  .recommendations-subtitle {
   margin: 0;
 }
 
-.magazine-categories.recommendations-container .recommendations-text-content .recommendations-truck {
+.magazine-categories.recommendations-container
+  .recommendations-text-content
+  .recommendations-truck {
   align-items: center;
   background-color: var(--c-secondary-steel);
   width: fit-content;
   opacity: 0.6;
 }
 
-.magazine-categories.recommendations-container .recommendations-text-content .recommendations-truck p {
+.magazine-categories.recommendations-container
+  .recommendations-text-content
+  .recommendations-truck
+  p {
   color: var(--c-primary-white);
   opacity: 0.8;
   margin: 0;
   padding: 2px 10px 0 5px;
 }
 
-.magazine-categories.recommendations-container .recommendations-text-content .recommendations-link {
+.magazine-categories.recommendations-container
+  .recommendations-text-content
+  .recommendations-link {
   padding: 5px 0;
 }
 
-.magazine-categories.recommendations-container .recommendations-text-content .recommendations-link::after {
+.magazine-categories.recommendations-container
+  .recommendations-text-content
+  .recommendations-link::after {
   content: url('../../media/arrow-B.webp');
   margin-left: 10px;
 }
@@ -208,8 +234,10 @@
     height: fit-content;
   }
 
-  .magazine-categories.recommendations-container .recommendations-item .recommendations-image,
-  .magazine-categories.recommendations-container  .recommendations-image  img {
+  .magazine-categories.recommendations-container
+    .recommendations-item
+    .recommendations-image,
+  .magazine-categories.recommendations-container .recommendations-image img {
     height: 270px;
   }
 }
@@ -223,8 +251,10 @@
     padding: 20px;
   }
 
-  .magazine-categories.recommendations-container .recommendations-item .recommendations-image,
-  .magazine-categories.recommendations-container  .recommendations-image  img {
+  .magazine-categories.recommendations-container
+    .recommendations-item
+    .recommendations-image,
+  .magazine-categories.recommendations-container .recommendations-image img {
     height: 240px;
     min-width: 360px;
   }
@@ -234,7 +264,7 @@
   .magazine-categories.recommendations-container .recommendations-list {
     flex-direction: column;
   }
-  
+
   .magazine-categories.recommendations-container .recommendations-item {
     width: unset;
   }
@@ -244,7 +274,8 @@
     overflow: hidden;
   }
 
-  main .section.magazine-categories.recommendations-container.recent-articles-container {
+  main
+    .section.magazine-categories.recommendations-container.recent-articles-container {
     display: flex;
     flex-flow: wrap;
     align-items: flex-start;

--- a/blocks/recommendations/recommendations.js
+++ b/blocks/recommendations/recommendations.js
@@ -1,97 +1,102 @@
 import {
   createElement,
-  getArticleTags,
   getOrigin,
   getTextLabel,
 } from '../../scripts/common.js';
 import {
-  getAllArticles,
-  getLimit,
+  fetchMagazineArticles,
+  getArticleTags,
+  extractLimitFromBlock,
   clearRepeatedArticles,
-  sortArticles,
-} from '../recent-articles/recent-articles.js';
-import {
-  getMetadata,
-  createOptimizedPicture,
-} from '../../scripts/aem.js';
+  sortArticlesByLastModifiedDate,
+  removeArticlesWithNoImage,
+} from '../../scripts/magazine-helper.js';
+import { getMetadata, createOptimizedPicture } from '../../scripts/aem.js';
 
 const recommendationsText = getTextLabel('Recommendations text');
 const readNowText = getTextLabel('READ NOW');
+const defaultLimit = 2;
+const blockName = 'recommendations';
 
 export default async function decorate(block) {
-  const limit = Number(getLimit(block));
+  const container = block.closest(`.${blockName}-container`);
+  const limit = extractLimitFromBlock(block) || defaultLimit;
   const category = await getArticleTags('categories') || getMetadata('category');
-  const allArticles = await getAllArticles();
+  const allArticles = await fetchMagazineArticles();
+  removeArticlesWithNoImage(allArticles);
 
   const recommendedArticles = allArticles.filter((e) => e.category === category);
-  const soredtArticles = sortArticles(recommendedArticles);
+  const soredtArticles = sortArticlesByLastModifiedDate(recommendedArticles);
   const filteredArticles = clearRepeatedArticles(soredtArticles);
   const selectedArticles = filteredArticles.slice(0, limit);
 
-  const recommendationsSection = createElement('div', { classes: 'recommendations-section' });
-  const recommendationsTitle = createElement('h3', { classes: 'recommendations-section-title' });
-  recommendationsTitle.innerText = recommendationsText;
+  if (selectedArticles.length !== 0) {
+    const recommendationsSection = createElement('div', { classes: `${blockName}-section` });
+    const recommendationsTitle = createElement('h3', { classes: `${blockName}-section-title` });
+    recommendationsTitle.innerText = recommendationsText;
 
-  const recommendationsList = createElement('ul', { classes: 'recommendations-list' });
+    const recommendationsList = createElement('ul', { classes: `${blockName}-list` });
 
-  selectedArticles.forEach((e, idx) => {
-    const item = createElement('li', { classes: ['recommendations-item', `recommendations-item-${idx}`] });
-    const linkUrl = new URL(e.path, getOrigin());
+    selectedArticles.forEach((e, idx) => {
+      const item = createElement('li', { classes: [`${blockName}-item`, `${blockName}-item-${idx}`] });
+      const linkUrl = new URL(e.path, getOrigin());
 
-    const image = createElement('div', { classes: 'recommendations-image' });
-    const picture = createOptimizedPicture(e.image, e.title);
-    const pictureTag = picture.outerHTML;
-    image.innerHTML = `<a href="${linkUrl}" class="image-link">
+      const image = createElement('div', { classes: `${blockName}-image` });
+      const picture = createOptimizedPicture(e.image, e.title);
+      const pictureTag = picture.outerHTML;
+      image.innerHTML = `<a href='${linkUrl}' class='image-link'>
       ${pictureTag}
     </a>`;
 
-    const categoriesWithDash = e.category.replaceAll(' ', '-').toLowerCase();
-    const categoryUrl = new URL(`magazine/categories/${categoriesWithDash}`, getOrigin());
+      const categoriesWithDash = e.category.replaceAll(' ', '-').toLowerCase();
+      const categoryUrl = new URL(`magazine/categories/${categoriesWithDash}`, getOrigin());
 
-    const content = createElement('div', { classes: 'recommendations-text-content' });
-    const categoryLink = createElement('a', {
-      classes: 'recommendations-category',
-      props: { href: categoryUrl },
+      const content = createElement('div', { classes: `${blockName}-text-content` });
+      const categoryLink = createElement('a', {
+        classes: `${blockName}-category`,
+        props: { href: categoryUrl },
+      });
+      categoryLink.innerText = e.category;
+
+      const title = createElement('a', {
+        classes: `${blockName}-title`,
+        props: { href: linkUrl },
+      });
+      title.innerText = e.title;
+
+      const truck = createElement('div', { classes: `${blockName}-truck` });
+      const truckText = createElement('p', { classes: `${blockName}-truck-text` });
+      truckText.innerText = e.truck;
+      const truckIcon = createElement('img', {
+        classes: 'truck-icon',
+        props: { src: '/icons/Truck_Key_icon.svg', alt: 'truck icon' },
+      });
+      if (e.truck.length !== 0) truck.append(truckIcon, truckText);
+
+      const link = createElement('a', {
+        classes: `${blockName}-link`,
+        props: { href: linkUrl },
+      });
+      link.innerText = readNowText;
+
+      content.append(categoryLink, title);
+
+      const subtitle = createElement('a', {
+        classes: `${blockName}-subtitle`,
+        props: { href: linkUrl },
+      });
+      subtitle.innerText = e.subtitle;
+      if (e.subtitle.length !== 0) {
+        content.append(subtitle);
+      }
+      content.append(truck, link);
+      item.append(image, content);
+      recommendationsList.append(item);
     });
-    categoryLink.innerText = e.category;
-
-    const title = createElement('a', {
-      classes: 'recommendations-title',
-      props: { href: linkUrl },
-    });
-    title.innerText = e.title;
-
-    const truck = createElement('div', { classes: 'recommendations-truck' });
-    const truckText = createElement('p', { classes: 'recommendations-truck-text' });
-    truckText.innerText = e.truck;
-    const truckIcon = createElement('img', {
-      classes: 'truck-icon',
-      props: { src: '/icons/Truck_Key_icon.svg', alt: 'truck icon' },
-    });
-    if (e.truck.length !== 0) truck.append(truckIcon, truckText);
-
-    const link = createElement('a', {
-      classes: 'recommendations-link',
-      props: { href: linkUrl },
-    });
-    link.innerText = readNowText;
-
-    content.append(categoryLink, title);
-
-    const subtitle = createElement('a', {
-      classes: 'recommendations-subtitle',
-      props: { href: linkUrl },
-    });
-    subtitle.innerText = e.subtitle;
-    if (e.subtitle.length !== 0) {
-      content.append(subtitle);
-    }
-    content.append(truck, link);
-    item.append(image, content);
-    recommendationsList.append(item);
-  });
-  recommendationsSection.append(recommendationsTitle, recommendationsList);
-
-  block.textContent = '';
-  block.append(recommendationsSection);
+    recommendationsSection.append(recommendationsTitle, recommendationsList);
+    block.textContent = '';
+    block.append(recommendationsSection);
+  } else {
+    container.remove();
+  }
 }

--- a/blocks/recommendations/recommendations.js
+++ b/blocks/recommendations/recommendations.js
@@ -10,7 +10,7 @@ import {
   clearRepeatedArticles,
   sortArticlesByLastModifiedDate,
   removeArticlesWithNoImage,
-} from '../../scripts/magazine-helper.js';
+} from '../../scripts/services/magazine.service.js';
 import { getMetadata, createOptimizedPicture } from '../../scripts/aem.js';
 
 const recommendationsText = getTextLabel('Recommendations text');
@@ -23,9 +23,9 @@ export default async function decorate(block) {
   const limit = extractLimitFromBlock(block) || defaultLimit;
   const category = await getArticleTags('categories') || getMetadata('category');
   const allArticles = await fetchMagazineArticles();
-  removeArticlesWithNoImage(allArticles);
+  const allArticlesWithImage = removeArticlesWithNoImage(allArticles);
 
-  const recommendedArticles = allArticles.filter((e) => e.category === category);
+  const recommendedArticles = allArticlesWithImage.filter((e) => e.category === category);
   const soredtArticles = sortArticlesByLastModifiedDate(recommendedArticles);
   const filteredArticles = clearRepeatedArticles(soredtArticles);
   const selectedArticles = filteredArticles.slice(0, limit);

--- a/blocks/v2-explore-articles/v2-explore-articles.js
+++ b/blocks/v2-explore-articles/v2-explore-articles.js
@@ -1,4 +1,9 @@
-import { decorateIcons, getJsonFromUrl, getTextLabel } from '../../scripts/common.js';
+import { decorateIcons, getTextLabel } from '../../scripts/common.js';
+import {
+  fetchMagazineArticles,
+  sortArticlesByDateInURL,
+  removeArticlesWithNoImage,
+} from '../../scripts/magazine-helper.js';
 import { createOptimizedPicture } from '../../scripts/aem.js';
 
 const LABELS = {
@@ -33,30 +38,12 @@ const defaultAmount = 9;
 let currentAmount = 0;
 
 const getData = async () => {
-  const allArticlesRaw = await getJsonFromUrl('/magazine-articles.json');
-  const allArticles = allArticlesRaw ? allArticlesRaw.data : [];
-
-  // sort data by date from newest to oldest
-  allArticles.sort((a, b) => {
-    const aPath = a.path.split('/');
-    const bPath = b.path.split('/');
-    const aYear = aPath[3];
-    const aMonth = aPath[4];
-    const bYear = bPath[3];
-    const bMonth = bPath[4];
-
-    const aDate = new Date(`${aYear}-${aMonth}`);
-    const bDate = new Date(`${bYear}-${bMonth}`);
-
-    if (aDate.getTime() === bDate.getTime()) {
-      return b.lastModified - a.lastModified;
-    }
-
-    return bDate - aDate;
-  });
+  const allArticles = await fetchMagazineArticles();
+  removeArticlesWithNoImage(allArticles);
+  const sortedArticlesByDate = sortArticlesByDateInURL(allArticles);
 
   // Preparing the data for every collage item
-  const collageItemsData = allArticles.map((article) => {
+  const collageItemsData = sortedArticlesByDate.map((article) => {
     const {
       title, image, path, category,
     } = article;

--- a/blocks/v2-explore-articles/v2-explore-articles.js
+++ b/blocks/v2-explore-articles/v2-explore-articles.js
@@ -3,7 +3,7 @@ import {
   fetchMagazineArticles,
   sortArticlesByDateInURL,
   removeArticlesWithNoImage,
-} from '../../scripts/magazine-helper.js';
+} from '../../scripts/services/magazine.service.js';
 import { createOptimizedPicture } from '../../scripts/aem.js';
 
 const LABELS = {
@@ -39,9 +39,8 @@ let currentAmount = 0;
 
 const getData = async () => {
   const allArticles = await fetchMagazineArticles();
-  removeArticlesWithNoImage(allArticles);
-  const sortedArticlesByDate = sortArticlesByDateInURL(allArticles);
-
+  const allArticlesWithImage = removeArticlesWithNoImage(allArticles);
+  const sortedArticlesByDate = sortArticlesByDateInURL(allArticlesWithImage);
   // Preparing the data for every collage item
   const collageItemsData = sortedArticlesByDate.map((article) => {
     const {

--- a/blocks/v2-magazine-tabbed-carousel/v2-magazine-tabbed-carousel.js
+++ b/blocks/v2-magazine-tabbed-carousel/v2-magazine-tabbed-carousel.js
@@ -1,10 +1,13 @@
 import {
   createElement,
   unwrapDivs,
-  getJsonFromUrl,
   getTextLabel,
   decorateIcons,
 } from '../../scripts/common.js';
+import {
+  removeArticlesWithNoImage,
+  fetchMagazineArticles,
+} from '../../scripts/magazine-helper.js';
 import { setCarouselPosition, listenScroll } from '../../scripts/carousel-helper.js';
 import { isVideoLink, createVideo } from '../../scripts/video-helper.js';
 
@@ -15,9 +18,8 @@ const activeCarouselClass = `${blockName}__carousel-item--active`;
 let autoScrollEnabled = true;
 const maxAmountOfTabs = 4;
 
-const url = '/magazine-articles.json';
-const allArticles = await getJsonFromUrl(url);
-const articleArray = Object.values(allArticles.data);
+const allArticles = await fetchMagazineArticles();
+removeArticlesWithNoImage(allArticles);
 
 let activeVideo = null;
 
@@ -180,7 +182,7 @@ export default async function decorate(block) {
 
   const tabItems = block.querySelectorAll(':scope > div');
 
-  buildTabItems(carouselItems, tabNavigation, tabItems, articleArray);
+  buildTabItems(carouselItems, tabNavigation, tabItems, allArticles);
 
   const handleAutoScroll = (isEnabled) => {
     if (isEnabled) {

--- a/blocks/v2-magazine-tabbed-carousel/v2-magazine-tabbed-carousel.js
+++ b/blocks/v2-magazine-tabbed-carousel/v2-magazine-tabbed-carousel.js
@@ -7,7 +7,7 @@ import {
 import {
   removeArticlesWithNoImage,
   fetchMagazineArticles,
-} from '../../scripts/magazine-helper.js';
+} from '../../scripts/services/magazine.service.js';
 import { setCarouselPosition, listenScroll } from '../../scripts/carousel-helper.js';
 import { isVideoLink, createVideo } from '../../scripts/video-helper.js';
 
@@ -19,7 +19,7 @@ let autoScrollEnabled = true;
 const maxAmountOfTabs = 4;
 
 const allArticles = await fetchMagazineArticles();
-removeArticlesWithNoImage(allArticles);
+const allArticlesWithImage = removeArticlesWithNoImage(allArticles);
 
 let activeVideo = null;
 
@@ -182,7 +182,7 @@ export default async function decorate(block) {
 
   const tabItems = block.querySelectorAll(':scope > div');
 
-  buildTabItems(carouselItems, tabNavigation, tabItems, allArticles);
+  buildTabItems(carouselItems, tabNavigation, tabItems, allArticlesWithImage);
 
   const handleAutoScroll = (isEnabled) => {
     if (isEnabled) {

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -310,7 +310,7 @@ export const slugify = (text) => (
 );
 
 /**
- * loads the constants file where configuration values are stored
+ * Loads the constants file where configuration values are stored
  */
 async function getConstantValues() {
   const url = `${getLanguagePath()}constants.json`;
@@ -327,6 +327,13 @@ async function getConstantValues() {
   return constants;
 }
 
+/**
+ * Extracts the values from an array in format: ['key1: value1', 'key2: value2', 'key3: value3']
+ * and returns this into an object with those keys and values:
+ * { key1: value1, key2: value2, key3: value3 }
+ * @param {Array} data - Array of strings that contain an object coming from sharepoint
+ * @returns {Object} An parsed object with those values and keys
+ */
 export const extractObjectFromArray = (data) => {
   const obj = {};
   for (const item of data) {
@@ -620,75 +627,6 @@ export const clearElementAttributes = (element) => {
 
   return element;
 };
-
-// Magazine common functions
-/**
- * Extracts the values from an array of objects and returns an array of values
- * example: [{ key: 'value' }] => ['value']
- * @param {Array} array - An array of objects
- * @returns {Array} An array of values
- */
-function getValuesFromObjectsArray(array = []) {
-  if (!Array.isArray(array) || array.length === 0) return [];
-  return array.map((item) => Object.values(item)[0]);
-}
-
-const fetchArticleTagsJSON = async () => getJsonFromUrl('/magazine/articles/tags.json');
-
-/**
- * Fetches the tags from the JSON file
- * @returns {Object} An object with the tags
- * @property {Array} categories - An array of categories
- * @property {Array} trucks - An array of trucks
- * @property {Array} topics - An array of topics
- */
-export const getArticleTagsJSON = async () => {
-  try {
-    const tagsJSON = await fetchArticleTagsJSON();
-
-    return {
-      categories: getValuesFromObjectsArray(tagsJSON.categories?.data),
-      trucks: getValuesFromObjectsArray(tagsJSON.trucks?.data),
-      topics: getValuesFromObjectsArray(tagsJSON.topics?.data),
-    };
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error('Error fetching article tags JSON:', error);
-    throw new Error('Unable to fetch article tags.');
-  }
-};
-
-/**
- * Extracts the matching tags from an array of tags and an array of article tags
- * and returns a string of matching tags
- * @param {Array} tags - An array of tags from the JSON file
- * @param {Array} articleTags - An array of article:tags
- * @returns {string} A string of matching tags
- */
-function getMetadataFromTags(tags, articleTags) {
-  if (!tags || !articleTags) {
-    return '';
-  }
-
-  const matchingTags = [...articleTags]
-    .filter((tag) => tags.includes(tag.content))
-    .map((tag) => tag.content);
-  return matchingTags && matchingTags?.length > 0 ? matchingTags.join(', ') : '';
-}
-
-/**
- * Get the article tags from the JSON file and the article tags from the document
- * and return the matching tags
- * @param {string} tagType - The type of tag to get such as 'categories', 'topics' or 'trucks'
- * @returns {string} A string of matching tags
- */
-export async function getArticleTags(tagType) {
-  const articleTags = document.head.querySelectorAll('meta[property="article:tag"]') || [];
-  const tagItems = await fetchArticleTagsJSON();
-  const tags = tagItems && tagItems[tagType]
-    && getValuesFromObjectsArray(tagItems[tagType].data);
-  return getMetadataFromTags(tags, articleTags);
-}
 
 /**
  * Get a HTML link element and adds the target=blank attribute if href is external

--- a/scripts/magazine-helper.js
+++ b/scripts/magazine-helper.js
@@ -1,0 +1,195 @@
+import { getJsonFromUrl } from './common.js';
+
+/**
+ * Fetches magazine articles from a given URL.
+ * @async
+ * @returns {Promise<Array>} - A promise that resolves to an array of article objects or an
+ * empty array if the fetch fails.
+ */
+export const fetchMagazineArticles = async () => {
+  try {
+    const response = await getJsonFromUrl('/magazine-articles.json');
+
+    if (!response?.data) {
+      // eslint-disable-next-line no-console
+      console.warn('No data found in response.');
+      return [];
+    }
+
+    const { data } = response;
+
+    return Array.isArray(data) ? data : [data];
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`Error fetching articles: ${error.message || error}`);
+    return [];
+  }
+};
+
+/**
+ * Extracts the articles that dont have an image field
+ * @param {Array} articles - An array of articles
+ * @returns {Array} - The same array of articles but without those that dont have an image field
+ */
+export const removeArticlesWithNoImage = (articles) => {
+  articles.forEach((art, idx) => {
+    if (!art.image) {
+      articles.splice(idx, 1);
+    }
+  });
+  return articles;
+};
+
+/**
+ * Extracts the values from an array of objects and returns an array of values
+ * example: [{ key: 'value' }] => ['value']
+ * @param {Array} array - An array of objects
+ * @returns {Array} An array of values
+ */
+export function getValuesFromObjectsArray(array = []) {
+  if (!Array.isArray(array) || array.length === 0) return [];
+  return array.map((item) => Object.values(item)[0]);
+}
+
+/**
+ * Extract the classes of a block and in case there is a 'limit-X' set, extract it as a number
+ * @param {block} block - The block element
+ * @returns {number} - A number representing the limit
+ */
+export const extractLimitFromBlock = (block) => {
+  let limit = null;
+  const blockClass = [...block.classList].find((className) => className.startsWith('limit-'));
+  if (blockClass) {
+    const [, value] = blockClass.split('-');
+    limit = Number(value);
+  }
+  return limit;
+};
+
+/**
+ * Checks the current URL to delete the same article from the other lists
+ * @param {Array} articles - The articles array
+ * @returns {Array} The articles without the opened one
+ */
+export const clearRepeatedArticles = (articles) => articles.filter((e) => {
+  const currentArticlePath = window.location.href.split('/').pop();
+  const path = e.path.split('/').pop();
+  if (path !== currentArticlePath) return e;
+  return null;
+});
+
+/**
+ * Sorts articles by the most recent `lastModified` date in descending order.
+ * @param {Array} articles - The array of article objects to be sorted.
+ * @returns {Array} - A new array of articles sorted by the most recent date.
+ */
+export const sortArticlesByLastModifiedDate = (articles) => articles
+  .map((article) => ({
+    ...article,
+    timestamp: new Date(article.lastModified).getTime(),
+  }))
+  .sort((a, b) => b.timestamp - a.timestamp);
+
+// TODO:
+// THESE FUNCTIONS SHOULD BE DEPRECATED AND DELETED
+// ONCE ALL METADATA TAGS ARE SET CORRECTLY
+/**
+ * Extract the classes of a block and in case there is a 'limit-X' set, extract it as a number
+ * @param {Object} article - The article element with all its fields
+ * @param {Array} allCategories - The block element
+ * @returns {number} - A number representing the limit
+ */
+export const getArticleCategory = (article, allCategories) => {
+  try {
+    const articleTags = JSON.parse(article.tags);
+    const categoriesSet = new Set(allCategories);
+    return articleTags.find((tag) => categoriesSet.has(tag)) || null;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error parsing article tags:', error);
+    return null;
+  }
+};
+
+/**
+ * Fetches the tags from the JSON file
+ * @returns {Array} An array of categories set in sharepoint
+ */
+export const fetchArticleTagsJSON = async () => getJsonFromUrl('/magazine/articles/tags.json');
+
+/**
+ * Fetches the tags from the JSON file
+ * @returns {Object} An object with the tags
+ * @property {Array} categories - An array of categories
+ * @property {Array} trucks - An array of trucks
+ * @property {Array} topics - An array of topics
+ */
+export const getArticleTagsJSON = async () => {
+  try {
+    const tagsJSON = await fetchArticleTagsJSON();
+
+    return {
+      categories: getValuesFromObjectsArray(tagsJSON.categories?.data),
+      trucks: getValuesFromObjectsArray(tagsJSON.trucks?.data),
+      topics: getValuesFromObjectsArray(tagsJSON.topics?.data),
+    };
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching article tags JSON:', error);
+    throw new Error('Unable to fetch article tags.');
+  }
+};
+
+/**
+ * Sorts the array of articles by the date that appears in the URL
+ * @param {Array} articles - The articles array
+ * @returns {Array} The same array but sorted
+ */
+export const sortArticlesByDateInURL = (articles) => articles.sort((a, b) => {
+  const aPath = a.path.split('/');
+  const bPath = b.path.split('/');
+  const aYear = aPath[3];
+  const aMonth = aPath[4];
+  const bYear = bPath[3];
+  const bMonth = bPath[4];
+
+  const aDate = new Date(`${aYear}-${aMonth}`);
+  const bDate = new Date(`${bYear}-${bMonth}`);
+
+  if (aDate.getTime() === bDate.getTime()) {
+    return b.lastModified - a.lastModified;
+  }
+  return bDate - aDate;
+});
+
+/**
+ * Extracts the matching tags from an array of tags and an array of article tags
+ * and returns a string of matching tags
+ * @param {Array} tags - An array of tags from the JSON file
+ * @param {Array} articleTags - An array of article:tags
+ * @returns {string} A string of matching tags
+ */
+export function getMetadataFromTags(tags, articleTags) {
+  if (!tags || !articleTags) {
+    return '';
+  }
+
+  const matchingTags = [...articleTags]
+    .filter((tag) => tags.includes(tag.content))
+    .map((tag) => tag.content);
+  return matchingTags && matchingTags?.length > 0 ? matchingTags.join(', ') : '';
+}
+
+/**
+ * Get the article tags from the JSON file and the article tags from the document
+ * and return the matching tags
+ * @param {string} tagType - The type of tag to get such as 'categories', 'topics' or 'trucks'
+ * @returns {string} A string of matching tags
+ */
+export async function getArticleTags(tagType) {
+  const articleTags = document.head.querySelectorAll('meta[property="article:tag"]') || [];
+  const tagItems = await fetchArticleTagsJSON();
+  const tags = tagItems && tagItems[tagType]
+    && getValuesFromObjectsArray(tagItems[tagType].data);
+  return getMetadataFromTags(tags, articleTags);
+}

--- a/scripts/services/magazine.service.js
+++ b/scripts/services/magazine.service.js
@@ -1,4 +1,4 @@
-import { getJsonFromUrl } from './common.js';
+import { getJsonFromUrl } from '../common.js';
 
 /**
  * Fetches magazine articles from a given URL.
@@ -32,12 +32,13 @@ export const fetchMagazineArticles = async () => {
  * @returns {Array} - The same array of articles but without those that dont have an image field
  */
 export const removeArticlesWithNoImage = (articles) => {
-  articles.forEach((art, idx) => {
+  const filteredArray = [...articles];
+  filteredArray.forEach((art, idx) => {
     if (!art.image) {
-      articles.splice(idx, 1);
+      filteredArray.splice(idx, 1);
     }
   });
-  return articles;
+  return filteredArray;
 };
 
 /**

--- a/scripts/services/magazine.service.js
+++ b/scripts/services/magazine.service.js
@@ -33,11 +33,7 @@ export const fetchMagazineArticles = async () => {
  */
 export const removeArticlesWithNoImage = (articles) => {
   const filteredArray = [...articles];
-  filteredArray.forEach((art, idx) => {
-    if (!art.image) {
-      filteredArray.splice(idx, 1);
-    }
-  });
+  filteredArray.filter((art) => !art.image);
   return filteredArray;
 };
 

--- a/templates/magazine/magazine.js
+++ b/templates/magazine/magazine.js
@@ -2,10 +2,8 @@ import {
   getMetadata,
   createOptimizedPicture,
 } from '../../scripts/aem.js';
-import {
-  createElement,
-  getArticleTags,
-} from '../../scripts/common.js';
+import { createElement } from '../../scripts/common.js';
+import { getArticleTags } from '../../scripts/magazine-helper.js';
 
 async function buildArticleHero({ truckTags, categoryTag } = {}) {
   const title = getMetadata('og:title');

--- a/templates/magazine/magazine.js
+++ b/templates/magazine/magazine.js
@@ -3,7 +3,7 @@ import {
   createOptimizedPicture,
 } from '../../scripts/aem.js';
 import { createElement } from '../../scripts/common.js';
-import { getArticleTags } from '../../scripts/magazine-helper.js';
+import { getArticleTags } from '../../scripts/services/magazine.service.js';
 
 async function buildArticleHero({ truckTags, categoryTag } = {}) {
   const title = getMetadata('og:title');


### PR DESCRIPTION
Fix #828

This PR also fixes some minor issues an cleans a bit the code that affects the following blocks:

v2-explore-articles
v2-magazine-tabbed-carousel
explore-articles
recommendations
recent-articles
(these last 2 can be found on the old magazine template)

Some test pages with the affected blocks are:

/drafts/shomps/v2-explore-articles
/drafts/shomps/v2-magazine-tabbed-carousel
/magazine/explore-articles
/magazine/articles/2023/august/choosing-mack-is-a-no-brainer

Test URLs:

Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
After: https://828-articles-no-images--vg-macktrucks-com--hlxsites.hlx.page/