### PR TITLE
Add video property in helix-query.yaml for magazine articles #753

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -118,6 +118,9 @@ indices:
       lastModified:
         select: none
         value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
+      video:
+        select: head > meta[name="video"]
+        value: match(attribute(el, "content"), "https:\/\/[^/]+(/.*)")
   search:
     include:
       - '/**'


### PR DESCRIPTION
Fix #753
Test URLs:
- Before: https://main--vg-macktrucks-com--hlxsites.hlx.page/
- After: https://753-add-video-property-helix-query--vg-macktrucks-com--hlxsites.hlx.page/
